### PR TITLE
fix: pass missing highlight class

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -31,7 +31,7 @@ name: Sam
 
 Simple paragraph
 
-\`\`\`typescript
+\`\`\`typescript[filename]{1-3,5}meta
 const a = 6;
 \`\`\`
 `)

--- a/src/runtime/parser/handlers/code.ts
+++ b/src/runtime/parser/handlers/code.ts
@@ -17,10 +17,10 @@ export default (state: State, node: Code) => {
     children: [{ type: 'text', value }]
   }
 
-  if (node.meta) {
+  if (meta) {
     result.data = {
       // @ts-ignore
-      meta: node.meta
+      meta
     }
   }
 
@@ -35,8 +35,8 @@ export default (state: State, node: Code) => {
     code: value
   }
 
-  if (node.lang) {
-    properties.className = ['language-' + node.lang]
+  if (language) {
+    properties.className = ['language-' + language]
   }
 
   // Create `<pre>`.

--- a/src/runtime/parser/handlers/utils.ts
+++ b/src/runtime/parser/handlers/utils.ts
@@ -11,7 +11,7 @@ export function parseThematicBlock (lang: string) {
     return {
       language: undefined,
       highlights: undefined,
-      fileName: undefined,
+      filename: undefined,
       meta: undefined
     }
   }

--- a/src/runtime/parser/shiki.ts
+++ b/src/runtime/parser/shiki.ts
@@ -20,7 +20,7 @@ const defaults: RehypeShikiOption = {
         code,
         lang,
         theme: JSON.stringify(theme),
-        highlights,
+        highlights: JSON.stringify(highlights)
       }
     })
   }
@@ -37,7 +37,7 @@ export function rehypeShiki (opts: RehypeShikiOption = {}) {
       node => (node as Element).tagName === 'pre' && !!(node as Element).properties?.language,
       (node) => {
         const _node = node as Element
-        const task = options.highlighter!(toString(node as any), _node.properties!.language as string, options.theme!, _node.properties!.highlights as number[])
+        const task = options.highlighter!(toString(node as any), _node.properties!.language as string, options.theme!, (_node.properties!.highlights ?? []) as number[])
           .then(({ tree, className, style }) => {
             _node.properties!.className = ((_node.properties!.className || '') + ' ' + className).trim()
 

--- a/src/runtime/parser/shiki.ts
+++ b/src/runtime/parser/shiki.ts
@@ -11,15 +11,16 @@ interface RehypeShikiOption {
 
 const defaults: RehypeShikiOption = {
   theme: {
-    default: 'github-dark',
-    dark: 'github-light'
+    default: 'github-light',
+    dark: 'github-dark'
   },
-  highlighter: (code, lang, theme) => {
+  highlighter: (code, lang, theme, highlights) => {
     return $fetch('/api/_mdc/highlight', {
       params: {
         code,
         lang,
-        theme: JSON.stringify(theme)
+        theme: JSON.stringify(theme),
+        highlights,
       }
     })
   }
@@ -36,7 +37,7 @@ export function rehypeShiki (opts: RehypeShikiOption = {}) {
       node => (node as Element).tagName === 'pre' && !!(node as Element).properties?.language,
       (node) => {
         const _node = node as Element
-        const task = options.highlighter!(toString(node as any), _node.properties!.language as string, options.theme!)
+        const task = options.highlighter!(toString(node as any), _node.properties!.language as string, options.theme!, _node.properties!.highlights as number[])
           .then(({ tree, className, style }) => {
             _node.properties!.className = ((_node.properties!.className || '') + ' ' + className).trim()
 

--- a/src/runtime/shiki/event-handler.ts
+++ b/src/runtime/shiki/event-handler.ts
@@ -4,14 +4,14 @@ import { useShikiHighlighter } from './highlighter'
 import type { Theme, TokenStyleMap } from './types'
 
 export default eventHandler(async (event) => {
-  const { code, lang, theme: themeString } = getQuery(event)
+  const { code, lang, theme: themeString } = getQuery(event) // where are the highlights?
   const theme = JSON.parse(themeString as string)
 
   const shikiHighlighter = useShikiHighlighter({})
 
   const styleMap: TokenStyleMap = {}
 
-  const {tree, className } = await shikiHighlighter.getHighlightedAST(code as string, lang as Lang, theme as Theme, { styleMap })
+  const {tree, className } = await shikiHighlighter.getHighlightedAST(code as string, lang as Lang, theme as Theme, { styleMap }) // missing highlights in options
 
   return {
     tree,

--- a/src/runtime/shiki/event-handler.ts
+++ b/src/runtime/shiki/event-handler.ts
@@ -4,14 +4,14 @@ import { useShikiHighlighter } from './highlighter'
 import type { Theme, TokenStyleMap } from './types'
 
 export default eventHandler(async (event) => {
-  const { code, lang, theme: themeString } = getQuery(event) // where are the highlights?
+  const { code, lang, theme: themeString, highlights } = getQuery(event)
   const theme = JSON.parse(themeString as string)
 
   const shikiHighlighter = useShikiHighlighter({})
 
   const styleMap: TokenStyleMap = {}
 
-  const {tree, className } = await shikiHighlighter.getHighlightedAST(code as string, lang as Lang, theme as Theme, { styleMap }) // missing highlights in options
+  const { tree, className } = await shikiHighlighter.getHighlightedAST(code as string, lang as Lang, theme as Theme, { styleMap, highlights: highlights as number[] })
 
   return {
     tree,

--- a/src/runtime/shiki/event-handler.ts
+++ b/src/runtime/shiki/event-handler.ts
@@ -4,14 +4,15 @@ import { useShikiHighlighter } from './highlighter'
 import type { Theme, TokenStyleMap } from './types'
 
 export default eventHandler(async (event) => {
-  const { code, lang, theme: themeString, highlights } = getQuery(event)
+  const { code, lang, theme: themeString, highlights: highlightsString } = getQuery(event)
   const theme = JSON.parse(themeString as string)
+  const highlights = JSON.parse(highlightsString as string) as number[]
 
   const shikiHighlighter = useShikiHighlighter({})
 
   const styleMap: TokenStyleMap = {}
 
-  const { tree, className } = await shikiHighlighter.getHighlightedAST(code as string, lang as Lang, theme as Theme, { styleMap, highlights: highlights as number[] })
+  const { tree, className } = await shikiHighlighter.getHighlightedAST(code as string, lang as Lang, theme as Theme, { styleMap, highlights })
 
   return {
     tree,

--- a/src/runtime/shiki/highlighter.ts
+++ b/src/runtime/shiki/highlighter.ts
@@ -27,7 +27,7 @@ const resolveTheme = (theme: string | Record<string, string>): Record<string, Sh
       default: theme
     }
   }
-  
+
   return Object.entries(theme).reduce((acc, [key, value]) => {
     acc[key] = BUNDLED_THEMES.find(t => t === value)!
     return acc
@@ -122,7 +122,7 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
     }
 
     // Highlight code
-    const coloredTokens = Object.entries(theme).map(([key, theme]) => {      
+    const coloredTokens = Object.entries(theme).map(([key, theme]) => {
       const tokens = highlighter.codeToThemedTokens(code, lang, theme, { includeExplanation: false })
         .map(line => line.map(token => ({
           content: token.content,
@@ -159,7 +159,7 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
     const { highlights = [], styleMap = {} } = opts || {}
 
     const className = Object.values(themeMap).map(th => th.name).join('_').replace('.', '')
-    
+
     styleMap[className] = {
       style: Object.entries(themeMap).reduce((acc, [key, th]) => {
         acc[key] = {
@@ -170,7 +170,7 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
       }, {} as Record<string, any>),
       className: className,
     }
-    
+
 
     const tree: Array<Element> = tokens.map((line, lineIndex) => {
       // Add line break to all lines except last

--- a/src/runtime/shiki/types.ts
+++ b/src/runtime/shiki/types.ts
@@ -18,7 +18,7 @@ export interface HighlightParams {
 
 export interface HighlighterOptions {
   styleMap: TokenStyleMap
-  highlights: Array<number>
+  highlights: number[]
 }
 
 export interface HighlightThemedToken {
@@ -31,4 +31,4 @@ export interface HighlightThemedTokenLine {
   tokens: HighlightThemedToken[]
 }
 
-export type Highlighter = (code: string, lang: string, theme: Theme) => Promise<{ tree: Element[], className: string, style: string }>
+export type Highlighter = (code: string, lang: string, theme: Theme, highlights: number[]) => Promise<{ tree: Element[], className: string, style: string }>


### PR DESCRIPTION
Supposed to fix #19 when ready

Currently, investigating where the highlights go missing in the process...
If you have any ideas, please share them.

---

In this function we never add/use highlights:
https://github.com/nuxt-modules/mdc/blob/9c357bf0fa12c2bf289ce432f8d4970b9738910c/src/runtime/parser/shiki.ts#L17

https://github.com/nuxt-modules/mdc/blob/9c357bf0fa12c2bf289ce432f8d4970b9738910c/src/runtime/parser/shiki.ts#L39