### PR TITLE
feat(MDC): accept parser options in `<MDC>`

### DIFF
--- a/src/runtime/components/MDC.vue
+++ b/src/runtime/components/MDC.vue
@@ -18,7 +18,8 @@
 import { hash } from 'ohash'
 import { useAsyncData } from 'nuxt/app'
 import { parseMarkdown } from '../parser'
-import { watch, computed } from 'vue'
+import { watch, computed, type PropType } from 'vue'
+import { MDCParseOptions } from '../types'
 
 const props = defineProps({
   tag: {
@@ -38,6 +39,13 @@ const props = defineProps({
   excerpt: {
     type: Boolean,
     default: false
+  },
+  /**
+   * Options for `parseMarkdown`
+   */
+  parserOptions: {
+    type: Object as PropType<MDCParseOptions>,
+    default: () => ({})
   }
 })
 
@@ -47,7 +55,7 @@ const { data, refresh } = await useAsyncData(key.value, async () => {
   if (typeof props.value !== 'string') {
     return props.value
   }
-  return await parseMarkdown(props.value)
+  return await parseMarkdown(props.value, props.parserOptions)
 })
 
 watch(() => props.value, () => {


### PR DESCRIPTION
Usage:
```vue
<template>
  <MDC v-slot="{ data, body }" :value="content" :parser-options="mdcOptions"/>
</template>

<script setup>
import { useShikiHighlighter } from '@nuxtjs/mdc/runtime'
const shikiHighlighter = useShikiHighlighter({})
const mdcOptions = {
    highlight: {
      highlighter: (code: string, lang: string, theme: any, highlights: any) => {
        return shikiHighlighter.getHighlightedAST(code, lang, theme, { highlights })
      },
      theme: {
        light: 'material-theme-lighter',
        default: 'material-theme',
        dark: 'material-theme-palenight'
      }
    }
}
</script>
```