### PR TITLE
fix: inline code highlighting

### DIFF
--- a/.github/scripts/bump-edge.ts
+++ b/.github/scripts/bump-edge.ts
@@ -13,7 +13,7 @@ async function main () {
   if (!workspace.packages.length) {
     workspace.packages.push(workspace.workspacePkg)
   }
-  
+
   for (const pkg of workspace.packages.filter(p => !p.data.private)) {
     const newVersion = inc(pkg.data.version, bumpType || 'patch')
     workspace.setVersion(pkg.data.name, `${newVersion}-${date}.${commit}`, {

--- a/.github/scripts/utils.ts
+++ b/.github/scripts/utils.ts
@@ -108,7 +108,7 @@ export async function determineBumpType () {
 
 export async function getLatestCommits () {
   const config = await loadChangelogConfig(process.cwd())
-  
+
   let latestRef
   try {
     latestRef = execaSync('git', ['describe', '--tags', '--abbrev=0']).stdout

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Hello MDC
 
 [MIT](./LICENSE) - Made with 💚
 
-
 <!-- Badges -->
 [npm-version-src]: https://img.shields.io/npm/v/@nuxtjs/mdc/latest.svg?style=flat&colorA=18181B&colorB=28CF8D
 [npm-version-href]: https://npmjs.com/package/@nuxtjs/mdc

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -34,10 +34,11 @@ name: Sam
 
 # Simple
 
-\`const codeInline: string = 'highlighted code inline'\`{language="ts"}
-
 Simple paragraph
 
+Inline code: \`const codeInline: string = 'highlighted code inline'\`{language="ts"}
+
+Code block:
 \`\`\`typescript[filename]{1,3-5}meta
 import { parseMarkdown } from '@nuxtjs/mdc/runtime'
 

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -36,7 +36,7 @@ name: Sam
 
 Simple paragraph
 
-Inline code: \`const codeInline: string = 'highlighted code inline'\`{language="ts"}
+Inline code: \`const codeInline: string = 'highlighted code inline'\`{lang="ts"}
 
 Code block:
 \`\`\`typescript[filename]{1,3-5}meta

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -34,6 +34,8 @@ name: Sam
 
 # Simple
 
+\`const codeInline: string = 'highlighted code inline'\`{language="ts"}
+
 Simple paragraph
 
 \`\`\`typescript[filename]{1,3-5}meta

--- a/src/runtime/components/MDCRenderer.vue
+++ b/src/runtime/components/MDCRenderer.vue
@@ -399,7 +399,7 @@ async function resolveContentComponents (body: MDCRoot, meta: Record<string, any
     }
 
     const renderTag: string = (typeof (node as MDCElement).props?.__ignoreMap === 'undefined' && documentMeta.tags[tag]) || tag
-    
+
     const components: string[] = []
     if (node.type !== 'root' && !htmlTags.includes(renderTag as any)) {
       components.push(renderTag)

--- a/src/runtime/parser/compiler.ts
+++ b/src/runtime/parser/compiler.ts
@@ -5,7 +5,7 @@ import Slugger from 'github-slugger'
 import { validateProps } from './utils/props'
 
 export function compileHast(this: any) {
-  // Create new slugger for each Tree to generate 
+  // Create new slugger for each Tree to generate
   const slugs = new Slugger()
 
   function compileToJSON(node: Root): MDCRoot;
@@ -80,7 +80,6 @@ export function compileHast(this: any) {
     return null
   }
 
-  
   this.Compiler = (tree: Root) => {
     const body = compileToJSON(tree)
 
@@ -100,7 +99,7 @@ export function compileHast(this: any) {
         }
       }
     }
-    
+
     return {
       body,
       excerpt

--- a/src/runtime/parser/handlers/inlineCode.ts
+++ b/src/runtime/parser/handlers/inlineCode.ts
@@ -15,6 +15,7 @@ export default function inlineCode (state: State, node: InlineCode & { attribute
   }
 
   const classes = (result.properties.class as string || '').split(' ')
+  delete result.properties.class
 
   if (language) {
     result.properties.language = language

--- a/src/runtime/parser/handlers/inlineCode.ts
+++ b/src/runtime/parser/handlers/inlineCode.ts
@@ -3,6 +3,7 @@ import { type Element, type Text, type Properties } from 'hast'
 import { type InlineCode } from 'mdast'
 
 export default function inlineCode (state: State, node: InlineCode & { attributes?: Properties }) {
+  const lang = node.attributes?.language ?? node.attributes?.lang
   const text: Text = { type: 'text', value: node.value.replace(/\r?\n|\r/g, ' ') }
   state.patch(node, text)
 
@@ -12,6 +13,12 @@ export default function inlineCode (state: State, node: InlineCode & { attribute
     properties: node.attributes || {},
     children: [text]
   }
+
+  if (lang) {
+    result.properties.language = lang
+    delete result.properties.lang
+  }
+
   state.patch(node, result)
   return state.applyData(node, result)
 }

--- a/src/runtime/parser/handlers/inlineCode.ts
+++ b/src/runtime/parser/handlers/inlineCode.ts
@@ -3,7 +3,7 @@ import { type Element, type Text, type Properties } from 'hast'
 import { type InlineCode } from 'mdast'
 
 export default function inlineCode (state: State, node: InlineCode & { attributes?: Properties }) {
-  const lang = node.attributes?.language ?? node.attributes?.lang
+  const language = node.attributes?.language || node.attributes?.lang
   const text: Text = { type: 'text', value: node.value.replace(/\r?\n|\r/g, ' ') }
   state.patch(node, text)
 
@@ -14,10 +14,16 @@ export default function inlineCode (state: State, node: InlineCode & { attribute
     children: [text]
   }
 
-  if (lang) {
-    result.properties.language = lang
+  const classes = (result.properties.class as string || '').split(' ')
+
+  if (language) {
+    result.properties.language = language
     delete result.properties.lang
+
+    classes.push('language-' + language)
   }
+
+  result.properties.className = classes.join(' ')
 
   state.patch(node, result)
   return state.applyData(node, result)

--- a/src/runtime/parser/index.ts
+++ b/src/runtime/parser/index.ts
@@ -18,7 +18,7 @@ export const parseMarkdown = async (md: string, opts: MDCParseOptions = {}) => {
     moduleOptions = await import('#mdc-imports' /* @vite-ignore */).catch(() => ({}))
   }
   const options = defu(opts, {
-    remark: { plugins: moduleOptions.remarkPlugins }, 
+    remark: { plugins: moduleOptions.remarkPlugins },
     rehype: { plugins: moduleOptions.rehypePlugins },
     highlight: moduleOptions.highlight,
   }, defaults)
@@ -76,7 +76,6 @@ export const parseMarkdown = async (md: string, opts: MDCParseOptions = {}) => {
     toc
   }
 }
-
 
 export function contentHeading (body: MDCRoot) {
   let title = ''

--- a/src/runtime/parser/shiki.ts
+++ b/src/runtime/parser/shiki.ts
@@ -34,7 +34,7 @@ export function rehypeShiki(opts: RehypeShikiOption = {}) {
     const styles: string[] = []
     visit(
       tree,
-      node => (node as Element).tagName === 'pre' && !!(node as Element).properties?.language,
+      node => ['pre', 'code'].includes((node as Element).tagName) && !!(node as Element).properties?.language,
       (node) => {
         const _node = node as Element
         const task = options.highlighter!(
@@ -50,7 +50,7 @@ export function rehypeShiki(opts: RehypeShikiOption = {}) {
             if ((_node.children[0] as Element)?.tagName === 'code') {
               (_node.children[0] as Element).children = tree
             } else {
-              _node.children = tree
+              _node.children = tree[0].children
             }
 
             if (style)

--- a/src/runtime/utils/node.ts
+++ b/src/runtime/utils/node.ts
@@ -118,7 +118,7 @@ export function flatUnwrap (vnodes: VNode | VNode[], tags: string | string[] = [
   if (typeof tags === 'string') {
     tags = tags.split(',').map(tag => tag.trim()).filter(Boolean)
   }
-  
+
   if (!tags.length) {
     return vnodes
   }

--- a/src/runtime/utils/ssrSlot.ts
+++ b/src/runtime/utils/ssrSlot.ts
@@ -5,6 +5,6 @@ export const ssrRenderSlot = (slots: Record<string, any>, name: string, props: a
   if (slots[name]) {
     return _ssrRenderSlot({ ...slots, [name]: () => flatUnwrap(slots[name](), props?.unwrap) }, name, props, fallbackRenderFn, push, parentComponent, slotScopeId)
   }
-  
+
   return _ssrRenderSlot(slots, name, props, fallbackRenderFn, push, parentComponent, slotScopeId)
 }

--- a/test/markdown/empty-paragraph.test.ts
+++ b/test/markdown/empty-paragraph.test.ts
@@ -4,7 +4,7 @@ import { parseMarkdown } from '../utils/parser'
 const md = `
 hello
 
-  
+
 
 world
 `.trim()

--- a/test/markdown/excerpt.test.ts
+++ b/test/markdown/excerpt.test.ts
@@ -13,7 +13,7 @@ Baz
 
 it('Excerpt', async () => {
   const { excerpt } = await parseMarkdown(md)
-    
+
   expect(excerpt).toHaveProperty('type', 'root')
   expect(excerpt).toHaveProperty('children[0].tag', 'h1')
   expect(excerpt).toHaveProperty('children[1].tag', 'p')

--- a/test/markdown/heading-id.test.ts
+++ b/test/markdown/heading-id.test.ts
@@ -7,7 +7,7 @@ const md = `
 # <a href="#xx" /> Foo
 ## C. Great
 ## 1. Introduction
-## ending space 
+## ending space
 ### Slash - in - Title
 ### -Starting dash
 ### Ending dash-
@@ -18,7 +18,7 @@ it('Heading id', async () => {
     const { data, body } = await parseMarkdown(md)
 
     expect(Object.keys(data)).toHaveLength(2)
-    
+
     expect(body.children).toMatchObject([
       { props: { id: 'hello'} },
       { props: { id: 'hello-world'} },

--- a/test/markdown/heading-id.test.ts
+++ b/test/markdown/heading-id.test.ts
@@ -7,7 +7,7 @@ const md = `
 # <a href="#xx" /> Foo
 ## C. Great
 ## 1. Introduction
-## ending space
+## ending space 
 ### Slash - in - Title
 ### -Starting dash
 ### Ending dash-

--- a/test/markdown/inline-code-highlighted.test.ts
+++ b/test/markdown/inline-code-highlighted.test.ts
@@ -1,0 +1,135 @@
+import { expect, it } from 'vitest'
+import { parseMarkdown } from '../utils/parser'
+
+const md = `
+\`const codeInline: string = 'highlighted code inline'\`{lang="ts"}
+`.trim()
+
+it('', async () => {
+    const { body } = await parseMarkdown(md, {
+        highlight: {
+            theme: 'github-dark'
+        }
+    })
+
+    expect(body).toHaveProperty('type', 'root')
+    expect(body.children).toHaveLength(2)
+    expect(body).toHaveProperty('children[0].tag', 'p')
+    expect(body).toHaveProperty('children[0].children[0].tag', 'code')
+    expect(body).toHaveProperty('children[0].children[0].props.language', 'ts')
+    expect(body).toHaveProperty('children[0].children[0].props.className', 'language-ts shiki shiki-themes github-dark')
+    expect(body).toMatchInlineSnapshot(`
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "const",
+                      },
+                    ],
+                    "props": {
+                      "style": "color:#F97583",
+                    },
+                    "tag": "span",
+                    "type": "element",
+                  },
+                  {
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": " codeInline",
+                      },
+                    ],
+                    "props": {
+                      "style": "color:#79B8FF",
+                    },
+                    "tag": "span",
+                    "type": "element",
+                  },
+                  {
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": ":",
+                      },
+                    ],
+                    "props": {
+                      "style": "color:#F97583",
+                    },
+                    "tag": "span",
+                    "type": "element",
+                  },
+                  {
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": " string",
+                      },
+                    ],
+                    "props": {
+                      "style": "color:#79B8FF",
+                    },
+                    "tag": "span",
+                    "type": "element",
+                  },
+                  {
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": " =",
+                      },
+                    ],
+                    "props": {
+                      "style": "color:#F97583",
+                    },
+                    "tag": "span",
+                    "type": "element",
+                  },
+                  {
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": " 'highlighted code inline'",
+                      },
+                    ],
+                    "props": {
+                      "style": "color:#9ECBFF",
+                    },
+                    "tag": "span",
+                    "type": "element",
+                  },
+                ],
+                "props": {
+                  "className": "language-ts shiki shiki-themes github-dark",
+                  "language": "ts",
+                  "style": "background-color:#24292e;color:#e1e4e8",
+                },
+                "tag": "code",
+                "type": "element",
+              },
+            ],
+            "props": {},
+            "tag": "p",
+            "type": "element",
+          },
+          {
+            "children": [
+              {
+                "type": "text",
+                "value": "",
+              },
+            ],
+            "props": {},
+            "tag": "style",
+            "type": "element",
+          },
+        ],
+        "type": "root",
+      }
+    `)
+})

--- a/test/markdown/inline-code-props.test.ts
+++ b/test/markdown/inline-code-props.test.ts
@@ -1,0 +1,42 @@
+import { expect, it } from 'vitest'
+import { parseMarkdown } from '../utils/parser'
+
+const md = `
+\`code\`{class="class-name-1 class-name-2"}
+`.trim()
+
+it('', async () => {
+  const { body } = await parseMarkdown(md)
+
+    expect(body).toHaveProperty('type', 'root')
+    expect(body).toHaveProperty('children[0].tag', 'p')
+    expect(body).toHaveProperty('children[0].children[0].tag', 'code')
+    expect(body).toHaveProperty('children[0].children[0].props.className', 'class-name-1 class-name-2')
+    expect(body).toMatchInlineSnapshot(`
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "code",
+                  },
+                ],
+                "props": {
+                  "className": "class-name-1 class-name-2",
+                },
+                "tag": "code",
+                "type": "element",
+              },
+            ],
+            "props": {},
+            "tag": "p",
+            "type": "element",
+          },
+        ],
+        "type": "root",
+      }
+    `)
+})

--- a/test/markdown/inline-code.test.ts
+++ b/test/markdown/inline-code.test.ts
@@ -7,7 +7,7 @@ const md = `
 
 it('Html `<code>` should render as inline code', async () => {
   const { body } = await parseMarkdown(md)
-  
+
   expect(body).toHaveProperty('type', 'root')
   expect(body).toHaveProperty('children[0].tag', 'p')
   expect(body).toHaveProperty('children[0].children[0].tag', 'code')

--- a/test/markdown/unwrap-slot.test.ts
+++ b/test/markdown/unwrap-slot.test.ts
@@ -5,7 +5,7 @@ const vnodes = [{__v_isVNode:true,__v_skip:true,type:'p',props:{},key:null,ref:n
 
 it('Unwrap tags', async () => {
   const withoutUnwrap = flatUnwrap(vnodes as any)
-  
+
   expect((withoutUnwrap as any)[0]).toHaveProperty('type', 'p')
   expect((withoutUnwrap as any)[0].children[0]).toHaveProperty('children', 'I am an alert!')
 

--- a/test/markdown/xss.test.ts
+++ b/test/markdown/xss.test.ts
@@ -34,8 +34,8 @@ const md = `\
 it('XSS', async () => {
     const { data, body } = await parseMarkdown(md)
 
-    expect(Object.keys(data)).toHaveLength(2)    
-    
+    expect(Object.keys(data)).toHaveLength(2)
+
     for (const node of (body.children[0] as MDCElement).children) {
       const props = (node as MDCElement).props || {}
       expect(Object.entries(props as Record<string, any>).every(([k, v]) => validateProp(k, v))).toBeTruthy()


### PR DESCRIPTION
### Issue/Discussion

fixes nuxt/content#2316

### Changes

Also parse `code` tag if it has a `language` prop.

> **Important**
> We probably have to add back `lang` instead of supporting *only* `language`, right? 
> Otherwise, this breaking change has to be mentioned (and changed everywhere in the docs, etc.).

What do you think about that?

Edit: added back support for `lang` property.

---

Also, for me, a general PR template would be helpful :)