### PR TITLE
feat: add default value to variable binding

### DIFF
--- a/src/runtime/components/MDCRenderer.vue
+++ b/src/runtime/components/MDCRenderer.vue
@@ -168,8 +168,9 @@ function renderBinding (node: MDCElement, h: CreateElement, documentMeta: MDCDat
     }
     return {}
   }, data)
+  const defaultValue = node.props?.defaultValue;
 
-  return h(Text, value)
+  return h(Text, value ?? defaultValue ?? '')
 }
 
 /**


### PR DESCRIPTION
It enables a convenient syntax for variable binding with default values. Now, you can use the following format in your Markdown documents: {{ $doc.variable | Default Value }}.

Linked to https://github.com/nuxtlabs/remark-mdc/pull/58