### PR TITLE
fix: drop !important css rules from code highlighting

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -59,6 +59,9 @@ async function main(mdc: string) {
 }
 .line.highlight {
   width: 100%;
-  background-color: #8882;
+  background-color: #8882 !important;
+}
+.line:empty::before {
+  content: "\200b";
 }
 </style>

--- a/src/runtime/components/prose/ProsePre.vue
+++ b/src/runtime/components/prose/ProsePre.vue
@@ -34,6 +34,8 @@ defineProps({
 <style>
 pre code .line {
   display: block;
-  min-height: 1rem;
+}
+pre code .line:empty::before {
+  content: "\200b";
 }
 </style>

--- a/src/runtime/shiki/highlighter.ts
+++ b/src/runtime/shiki/highlighter.ts
@@ -85,11 +85,11 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
       .map(color => [
         wrapperStyle ? `html.${color} .shiki,` : '',
         `html.${color} .shiki span {`,
-        `color: var(--shiki-${color}) !important;`,
-        `background: var(--shiki-${color}-bg) !important;`,
-        `font-style: var(--shiki-${color}-font-style) !important;`,
-        `font-weight: var(--shiki-${color}-font-weight) !important;`,
-        `text-decoration: var(--shiki-${color}-text-decoration) !important;`,
+        `color: var(--shiki-${color});`,
+        `background: var(--shiki-${color}-bg);`,
+        `font-style: var(--shiki-${color}-font-style);`,
+        `font-weight: var(--shiki-${color}-font-weight);`,
+        `text-decoration: var(--shiki-${color}-text-decoration);`,
         '}'
       ].join('').trim())
       .join('\n')

--- a/src/runtime/shiki/highlighter.ts
+++ b/src/runtime/shiki/highlighter.ts
@@ -61,7 +61,7 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
     const root = highlighter.codeToHast(code.trimEnd(), {
       lang,
       themes: themesObject,
-      defaultColor: 'default',
+      defaultColor: false,
       transforms: {
         line(node, line) {
           node.properties ||= {}
@@ -76,22 +76,22 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
     const preEl = root.children[0] as Element
     const codeEl = preEl.children[0] as Element
 
-    preEl.properties.style = wrapperStyle ?
-      (typeof wrapperStyle === 'string' ? wrapperStyle : preEl.properties.style) :
-      ''
+    preEl.properties.style = wrapperStyle ? (typeof wrapperStyle === 'string' ? wrapperStyle : preEl.properties.style) : ''
 
     const style = Object.keys(themesObject)
-      .filter(color => color !== 'default')
-      .map(color => [
-        wrapperStyle ? `html.${color} .shiki,` : '',
-        `html.${color} .shiki span {`,
-        `color: var(--shiki-${color});`,
-        `background: var(--shiki-${color}-bg);`,
-        `font-style: var(--shiki-${color}-font-style);`,
-        `font-weight: var(--shiki-${color}-font-weight);`,
-        `text-decoration: var(--shiki-${color}-text-decoration);`,
-        '}'
-      ].join('').trim())
+      .map(color => {
+        const colorScheme = color !== 'default' ? `.${color}` : ''
+        return [
+          wrapperStyle ? `html${colorScheme} .shiki,` : '',
+          `html${colorScheme} .shiki span {`,
+          `color: var(--shiki-${color});`,
+          `background: var(--shiki-${color}-bg);`,
+          `font-style: var(--shiki-${color}-font-style);`,
+          `font-weight: var(--shiki-${color}-font-weight);`,
+          `text-decoration: var(--shiki-${color}-text-decoration);`,
+          '}'
+        ].join('').trim()
+      })
       .join('\n')
 
     return {

--- a/test/markdown/code-block-highlighted.test.ts
+++ b/test/markdown/code-block-highlighted.test.ts
@@ -33,7 +33,7 @@ it('Highlighted code block', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#F97583",
+                      "style": "--shiki-default:#F97583",
                     },
                     "tag": "span",
                     "type": "element",
@@ -46,7 +46,7 @@ it('Highlighted code block', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#B392F0",
+                      "style": "--shiki-default:#B392F0",
                     },
                     "tag": "span",
                     "type": "element",
@@ -59,7 +59,7 @@ it('Highlighted code block', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#E1E4E8",
+                      "style": "--shiki-default:#E1E4E8",
                     },
                     "tag": "span",
                     "type": "element",
@@ -82,7 +82,7 @@ it('Highlighted code block', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#F97583",
+                      "style": "--shiki-default:#F97583",
                     },
                     "tag": "span",
                     "type": "element",
@@ -95,7 +95,7 @@ it('Highlighted code block', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#FFAB70",
+                      "style": "--shiki-default:#FFAB70",
                     },
                     "tag": "span",
                     "type": "element",
@@ -108,7 +108,7 @@ it('Highlighted code block', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#F97583",
+                      "style": "--shiki-default:#F97583",
                     },
                     "tag": "span",
                     "type": "element",
@@ -121,7 +121,7 @@ it('Highlighted code block', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#79B8FF",
+                      "style": "--shiki-default:#79B8FF",
                     },
                     "tag": "span",
                     "type": "element",
@@ -134,7 +134,7 @@ it('Highlighted code block', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#F97583",
+                      "style": "--shiki-default:#F97583",
                     },
                     "tag": "span",
                     "type": "element",
@@ -147,7 +147,7 @@ it('Highlighted code block', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#9ECBFF",
+                      "style": "--shiki-default:#9ECBFF",
                     },
                     "tag": "span",
                     "type": "element",
@@ -170,7 +170,7 @@ it('Highlighted code block', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#E1E4E8",
+                      "style": "--shiki-default:#E1E4E8",
                     },
                     "tag": "span",
                     "type": "element",
@@ -210,7 +210,7 @@ it('Highlighted code block', async () => {
         "children": [
           {
             "type": "text",
-            "value": "",
+            "value": "html .shiki span {color: var(--shiki-default);background: var(--shiki-default-bg);font-style: var(--shiki-default-font-style);font-weight: var(--shiki-default-font-weight);text-decoration: var(--shiki-default-text-decoration);}",
           },
         ],
         "props": {},

--- a/test/markdown/inline-code-highlighted.test.ts
+++ b/test/markdown/inline-code-highlighted.test.ts
@@ -33,7 +33,7 @@ it('', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#F97583",
+                      "style": "--shiki-default:#F97583",
                     },
                     "tag": "span",
                     "type": "element",
@@ -46,7 +46,7 @@ it('', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#79B8FF",
+                      "style": "--shiki-default:#79B8FF",
                     },
                     "tag": "span",
                     "type": "element",
@@ -59,7 +59,7 @@ it('', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#F97583",
+                      "style": "--shiki-default:#F97583",
                     },
                     "tag": "span",
                     "type": "element",
@@ -72,7 +72,7 @@ it('', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#79B8FF",
+                      "style": "--shiki-default:#79B8FF",
                     },
                     "tag": "span",
                     "type": "element",
@@ -85,7 +85,7 @@ it('', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#F97583",
+                      "style": "--shiki-default:#F97583",
                     },
                     "tag": "span",
                     "type": "element",
@@ -98,7 +98,7 @@ it('', async () => {
                       },
                     ],
                     "props": {
-                      "style": "color:#9ECBFF",
+                      "style": "--shiki-default:#9ECBFF",
                     },
                     "tag": "span",
                     "type": "element",
@@ -121,7 +121,7 @@ it('', async () => {
             "children": [
               {
                 "type": "text",
-                "value": "",
+                "value": "html .shiki span {color: var(--shiki-default);background: var(--shiki-default-bg);font-style: var(--shiki-default-font-style);font-weight: var(--shiki-default-font-weight);text-decoration: var(--shiki-default-text-decoration);}",
               },
             ],
             "props": {},


### PR DESCRIPTION
resolve nuxt/content#2366

Will try to drop `!important` rules, to allow overriding them without the need to specify `!important` yourself.

- use no default for code block color scheme, to allow overriding without `!important`
- update tests

---

On the side also changed:
- use `\200b` instead of `1rem` (which is not (necessarily) the right height) to keep line height of empty lines;
  `\200b` is a no-width line height blank character
- fixed highlight color display for project dev mode

The `!important` [here](https://github.com/nuxt-modules/mdc/pull/61/files#diff-4e70dbb4315c851802969484f0b6cf566eda24aeb43dc8b6c413e575488713d0R62) is just for dev purposes in this project, and is applied, because the current specificity is not high enough to override the other rule (could also change that code to have a high enough specificity)