### PR TITLE
feat(shiki): remove `html` from `.shiki` css selector

### DIFF
--- a/src/runtime/shiki/highlighter.ts
+++ b/src/runtime/shiki/highlighter.ts
@@ -83,8 +83,8 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
         .map(color => {
           const colorScheme = color !== 'default' ? `.${color}` : ''
           return [
-            wrapperStyle ? `html${colorScheme} .shiki,` : '',
-            `html${colorScheme} .shiki span {`,
+            wrapperStyle ? `${colorScheme} .shiki,` : '',
+            `${colorScheme} .shiki span {`,
             `color: var(--shiki-${color});`,
             `background: var(--shiki-${color}-bg);`,
             `font-style: var(--shiki-${color}-font-style);`,
@@ -110,7 +110,6 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
         style: ''
       }
     }
-  
   }
 
   return {

--- a/test/markdown/code-block-highlighted.test.ts
+++ b/test/markdown/code-block-highlighted.test.ts
@@ -210,7 +210,7 @@ it('Highlighted code block', async () => {
         "children": [
           {
             "type": "text",
-            "value": "html .shiki span {color: var(--shiki-default);background: var(--shiki-default-bg);font-style: var(--shiki-default-font-style);font-weight: var(--shiki-default-font-weight);text-decoration: var(--shiki-default-text-decoration);}",
+            "value": ".shiki span {color: var(--shiki-default);background: var(--shiki-default-bg);font-style: var(--shiki-default-font-style);font-weight: var(--shiki-default-font-weight);text-decoration: var(--shiki-default-text-decoration);}",
           },
         ],
         "props": {},

--- a/test/markdown/inline-code-highlighted.test.ts
+++ b/test/markdown/inline-code-highlighted.test.ts
@@ -121,7 +121,7 @@ it('', async () => {
             "children": [
               {
                 "type": "text",
-                "value": "html .shiki span {color: var(--shiki-default);background: var(--shiki-default-bg);font-style: var(--shiki-default-font-style);font-weight: var(--shiki-default-font-weight);text-decoration: var(--shiki-default-text-decoration);}",
+                "value": ".shiki span {color: var(--shiki-default);background: var(--shiki-default-bg);font-style: var(--shiki-default-font-style);font-weight: var(--shiki-default-font-weight);text-decoration: var(--shiki-default-text-decoration);}",
               },
             ],
             "props": {},


### PR DESCRIPTION
At the moment, the style generated looks like this:

![CleanShot 2023-10-13 at 17 01 16@2x](https://github.com/nuxt-modules/mdc/assets/739984/ca17497b-27c9-4ad7-b586-6edea734ae94)

Removing the `html` selector would let us highlight with the dark theme when in light mode by adding the `dark` class on a section.

Example of what we're trying to do on nuxt.com (we can see its using the light theme although I've added a `dark` class around):

![CleanShot 2023-10-13 at 17 03 12@2x](https://github.com/nuxt-modules/mdc/assets/739984/591c0057-edf4-406a-a0c4-9c280b07ff5b)
![CleanShot 2023-10-13 at 17 04 15@2x](https://github.com/nuxt-modules/mdc/assets/739984/68cad21a-fe0c-4fe8-b775-68db71d93261)

