### PR TITLE
chore(code block): drop empty line styles

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -35,7 +35,7 @@ name: Sam
 
 Simple paragraph
 
-Inline code: \`const codeInline: string = 'highlighted code inline'\`{lang="ts"}
+Inline code \`const codeInline: string = 'highlighted code inline'\`{lang="ts"} can be contained in paragraphs.
 
 Code block:
 \`\`\`typescript[filename]{1,3-5}meta
@@ -59,8 +59,5 @@ async function main(mdc: string) {
 .line.highlight {
   width: 100%;
   background-color: #8882 !important;
-}
-.line:empty::before {
-  content: "\200b";
 }
 </style>

--- a/src/runtime/components/prose/ProsePre.vue
+++ b/src/runtime/components/prose/ProsePre.vue
@@ -35,7 +35,4 @@ defineProps({
 pre code .line {
   display: block;
 }
-pre code .line:empty::before {
-  content: "\200b";
-}
 </style>

--- a/src/runtime/shiki/highlighter.ts
+++ b/src/runtime/shiki/highlighter.ts
@@ -85,7 +85,7 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
             const last = node.children.at(-1)
             if (last?.type === 'element' && last.tagName === 'span') {
               const text = last.children.at(-1)
-              
+
               if (text?.type === 'text')
                 text.value += '\n'
             }
@@ -102,7 +102,7 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
       Object.keys(themesObject)
         .forEach(color => {
           const colorScheme = color !== 'default' ? `.${color}` : ''
-          
+
           styles.push(
             wrapperStyle ? `${colorScheme} .shiki,` : '',
             `html .${color} .shiki span {`,


### PR DESCRIPTION
Drop the styles for empty lines in a code block.

This is not needed anymore, as every empty line now contains a newline character (`\n`) which takes the full height of a character.

This now works again because of #62.

Also, since the lines are now never really empty (span with newline / span with text+newline / text), this rule wouldn't even be applied.

