### PR TITLE
feat: add script render in mdc

### DIFF
--- a/src/runtime/components/MDCRenderer.vue
+++ b/src/runtime/components/MDCRenderer.vue
@@ -20,7 +20,7 @@ const rxBind = /^:|^v-bind:/
 const rxModel = /^v-model/
 const nativeInputs = ['select', 'textarea', 'input']
 
-const proseComponentMap = Object.fromEntries(['p', 'a', 'blockquote', 'code', 'pre', 'code', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'img', 'ul', 'ol', 'li', 'strong', 'table', 'thead', 'tbody', 'td', 'th', 'tr'].map(t => [t, `prose-${t}`]))
+const proseComponentMap = Object.fromEntries(['p', 'a', 'blockquote', 'code', 'pre', 'code', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'img', 'ul', 'ol', 'li', 'strong', 'table', 'thead', 'tbody', 'td', 'th', 'tr', 'script'].map(t => [t, `prose-${t}`]))
 
 export default defineComponent({
   name: 'MDCRenderer',
@@ -96,7 +96,7 @@ export default defineComponent({
     const component: string | ConcreteComponent = tag !== false ? resolveVueComponent((tag || meta.component?.name || meta.component || 'div') as string) : undefined
 
     const childrenRendrer = renderSlots(body, h, meta, meta)
-    
+
     // Return Vue component
     return component
       ? h(component as any, { ...meta.component?.props, ...this.$attrs, key: contentKey }, childrenRendrer)
@@ -115,9 +115,9 @@ function renderNode (node: MDCNode, h: CreateElement, documentMeta: MDCData, par
     return h(Text, node.value)
   }
 
-  if (node.tag === 'script') {
-    return h(Text, renderToText(node))
-  }
+  // if (node.tag === 'script') {
+  //   return h(Text, renderToText(node))
+  // }
 
   const originalTag = node.tag!
   // `_ignoreMap` is an special prop to disables tag-mapper
@@ -388,7 +388,7 @@ async function resolveContentComponents (body: MDCRoot, meta: Record<string, any
   if (!body) {
     return
   }
-  
+
   const components = Array.from(new Set(loadComponents(body, meta)))
   await Promise.all(components.map(async (c: any) => {
     if (c?.render || c?.ssrRender || c?.__ssrInlineRender) {
@@ -422,7 +422,7 @@ async function resolveContentComponents (body: MDCRoot, meta: Record<string, any
 
 function findMappedTag (node: MDCElement, tags: Record<string, string>) {
   const tag = node.tag
-  
+
   if (!tag || typeof (node as MDCElement).props?.__ignoreMap !== 'undefined') {
     return tag
   }

--- a/src/runtime/components/MDCRenderer.vue
+++ b/src/runtime/components/MDCRenderer.vue
@@ -115,10 +115,6 @@ function renderNode (node: MDCNode, h: CreateElement, documentMeta: MDCData, par
     return h(Text, node.value)
   }
 
-  // if (node.tag === 'script') {
-  //   return h(Text, renderToText(node))
-  // }
-
   const originalTag = node.tag!
   // `_ignoreMap` is an special prop to disables tag-mapper
   const renderTag: string = findMappedTag(node as MDCElement, documentMeta.tags)
@@ -139,18 +135,6 @@ function renderNode (node: MDCNode, h: CreateElement, documentMeta: MDCData, par
     props,
     renderSlots(node, h, documentMeta, { ...parentScope, ...props })
   )
-}
-
-function renderToText (node: MDCNode): string {
-  if (node.type === 'text') {
-    return node.value!
-  }
-
-  if (!node.children?.length) {
-    return `<${node.tag}>`
-  }
-
-  return `<${node.tag}>${node.children?.map(renderToText).join('') || ''}</${node.tag}>`
 }
 
 function renderBinding (node: MDCElement, h: CreateElement, documentMeta: MDCData, parentScope: any = {}): VNode {

--- a/src/runtime/components/prose/ProseScript.vue
+++ b/src/runtime/components/prose/ProseScript.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    This is possibly dangerous, you should implement your own <ProseCode>ProseScript</ProseCode> element.
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps({
+  src: {
+    type: String,
+    default: ''
+  }
+})
+</script>

--- a/src/runtime/components/prose/ProseScript.vue
+++ b/src/runtime/components/prose/ProseScript.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    This is possibly dangerous, you should implement your own <ProseCode>ProseScript</ProseCode> element.
+    Rendering the <ProseCode>script</ProseCode> element is dangerous and is disabled by default. Consider implementing your own <ProseCode>ProseScript</ProseCode> element to have control over script rendering.
   </div>
 </template>
 


### PR DESCRIPTION
Sometimes when building a blog with markdown, using Gist is essential, but mdc did not have support for rendering script tag, this was my problem when I tried to use Gist on my Blog.

Each and every script was rendered as simple text like the following: `<script>`.

I added a `ProseScript` which by default also doesn't render the script, just a warning message, but now the user can override this element with their own, just like the other `Prose*` elements.

My issue is: #70 