### PR TITLE
feat: add title and description on markdown returned type

### DIFF
--- a/src/runtime/types/tree.ts
+++ b/src/runtime/types/tree.ts
@@ -17,4 +17,7 @@ export type MDCRoot = {
   children: Array<MDCNode>
 }
 
-export interface MDCData extends Record<string, any> {}
+export interface MDCData extends Record<string, any> {
+  title: string,
+  description: string,
+}


### PR DESCRIPTION
Hello,

Even if there is no filename, heading 1 or title in frontmatter, the data object always have a title key and a description key.

Adding these will allow use to remove `| undefined` in https://github.com/nuxt/content/blob/5f059f81478ef6e64c5a63db9da24b80ae337176/src/runtime/types/index.d.ts#L20
