### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/src/runtime/components/MDCRenderer.vue
+++ b/src/runtime/components/MDCRenderer.vue
@@ -4,7 +4,7 @@ import destr from 'destr'
 import { kebabCase, pascalCase } from 'scule'
 import { find, html } from 'property-information'
 import type { VNode, ConcreteComponent, PropType, DefineComponent } from 'vue'
-import { useRoute, useRuntimeConfig } from '#app'
+import { useRoute, useRuntimeConfig } from '#imports'
 import htmlTags from '../parser/utils/html-tags-list'
 import type { MDCElement, MDCNode, MDCRoot, MDCData } from '../types'
 


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.