### PR TITLE
feat(highlighter): support text/unknown/no language line highlights

### DIFF
--- a/src/runtime/shiki/highlighter.ts
+++ b/src/runtime/shiki/highlighter.ts
@@ -81,7 +81,7 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
 
             // Add newline to end of lines if needed
             if (code?.includes('\n')) {
-              // Add newline for empty lines; If no language is defined: Empty lines are represented by a span containing a span containing an empty text node
+              // Set newline for empty lines
               if (node.children.length === 0 || (
                 node.children.length === 1 && node.children[0].type === 'element' &&
                 node.children[0].children.length === 1 && node.children[0].children[0].type === 'text' &&
@@ -93,8 +93,9 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
                   properties: {
                     emptyLinePlaceholder: true
                   },
-                  children: [{ type: 'text', value: '' }]
+                  children: [{ type: 'text', value: '\n' }]
                 }]
+                return
               }
 
               // Add newline to end of lines

--- a/src/runtime/shiki/highlighter.ts
+++ b/src/runtime/shiki/highlighter.ts
@@ -56,7 +56,15 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
       }
 
       if (lang && !highlighter.getLoadedLanguages().includes(lang)) {
-        await highlighter.loadLanguage(lang)
+        try {
+          await highlighter.loadLanguage(lang)
+        } catch (error: any) {
+          if (highlights.length) {
+            console.warn('[@nuxtjs/mdc] Defaulting to no language to be able to highlight lines:', error.message)
+            // @ts-ignore
+            lang = ''
+          } else throw error
+        }
       }
 
       const root = highlighter.codeToHast(code.trimEnd(), {
@@ -73,17 +81,23 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
 
             // Add newline to end of lines if needed
             if (code?.includes('\n')) {
-              // Add newline to end of lines
-              if (node.children.length === 0) {
-                node.children.push({
+              // Add newline for empty lines; If no language is defined: Empty lines are represented by a span containing a span containing an empty text node
+              if (node.children.length === 0 || (
+                node.children.length === 1 && node.children[0].type === 'element' &&
+                node.children[0].children.length === 1 && node.children[0].children[0].type === 'text' &&
+                node.children[0].children[0].value === ''
+              )) {
+                node.children = [{
                   type: 'element',
                   tagName: 'span',
                   properties: {
                     emptyLinePlaceholder: true
                   },
                   children: [{ type: 'text', value: '' }]
-                })
+                }]
               }
+
+              // Add newline to end of lines
               const last = node.children.at(-1)
               if (last?.type === 'element' && last.tagName === 'span') {
                 const text = last.children.at(-1)
@@ -135,7 +149,7 @@ export const useShikiHighlighter = createSingleton((opts?: any) => {
         style: styles.join(''),
       }
     } catch (error: any) {
-      console.warn('[@nuxtjs/mdc] Failed to highlight code block', error.message)
+      console.warn('[@nuxtjs/mdc] Failed to highlight code block:', error.message)
       return {
         tree: [{ type: 'text', value: code }],
         className: '',

--- a/src/runtime/shiki/index.ts
+++ b/src/runtime/shiki/index.ts
@@ -48,7 +48,7 @@ export function rehypeShiki(opts: RehypeShikiOption = {}) {
     const styles: string[] = []
     visit(
       tree,
-      node => ['pre', 'code'].includes((node as Element).tagName) && !!(node as Element).properties?.language,
+      node => ['pre', 'code'].includes((node as Element).tagName) && !!((node as Element).properties?.language || (node as Element).properties?.highlights),
       (node) => {
         const _node = node as Element
         const task = options.highlighter!(


### PR DESCRIPTION
fixes #72

- pass code to highlighter too, if `highlights` are defined
- check if `lang` cannot be loaded by `shikiji`:
  - highlights defined? Set `lang` to `''`
  - otherwise, pass on `lang not found` error
- text/without `lang` has `<span><span>text</span</span>` as children (highlighted empty line has no children)

It might be better to change the last point in `shiki` / `shikiji`? (And then remove line `86`-`88` here)

---

> [!Note]
> I'm not sure, if it is better when all code block code's (regardless of highlighting (code / lines) or not) should be split to lines.
> Then every code block would behave the same when they are styled.
> This would work by just not differentiating if it has line highlights or not when changing the language to `''` and also changing the `if` statement for checking the lang / highlights prop.
> (There would have to be logic to not pass `<pre>` and inner `<code>` separately, which is currently ensured by lang/highlights prop)