### PR TITLE
fix: only append new entry to `optimizeDeps` on `vite:extendConfig`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -53,9 +53,15 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     nuxt.hook('vite:extendConfig', (viteConfig) => {
-      viteConfig.optimizeDeps?.include?.push(
-        'is-buffer', 'debug', 'flat', 'node-emoji', 'extend', 'hast-util-raw'
-      )
+      const optimizeList = ['is-buffer', 'debug', 'flat', 'node-emoji', 'extend', 'hast-util-raw']
+
+      viteConfig.optimizeDeps ||= {}
+      viteConfig.optimizeDeps.include ||= []
+      optimizeList.forEach((pkg) => {
+        if (!viteConfig.optimizeDeps.include.includes(pkg)) {
+          viteConfig.optimizeDeps.include.push(pkg)
+        }
+      })
     })
 
     // Enable wasm for shikiji

--- a/src/module.ts
+++ b/src/module.ts
@@ -57,9 +57,10 @@ export default defineNuxtModule<ModuleOptions>({
 
       viteConfig.optimizeDeps ||= {}
       viteConfig.optimizeDeps.include ||= []
+      const list = viteConfig.optimizeDeps.include
       optimizeList.forEach((pkg) => {
-        if (!viteConfig.optimizeDeps.include.includes(pkg)) {
-          viteConfig.optimizeDeps.include.push(pkg)
+        if (!list.includes(pkg)) {
+          list.push(pkg)
         }
       })
     })


### PR DESCRIPTION
https://github.com/nuxt/nuxt/issues/24196#issuecomment-1853505843

While https://github.com/vitejs/vite/pull/15337 fixes it on the upstream, I still think it's better for us to also do the check so it works for existing users