### PR TITLE
feat: enable wasm with unwasm for highlighter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ coverage
 
 # VSCode
 .vscode/*
-!.vscode/settings.json
+.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "ufo": "^1.3.2",
     "unified": "^11.0.4",
     "unist-builder": "^4.0.0",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit": "^5.0.0",
+    "unwasm": "^0.3.2"
   },
   "devDependencies": {
     "@nuxt/devtools": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ dependencies:
   unist-util-visit:
     specifier: ^5.0.0
     version: 5.0.0
+  unwasm:
+    specifier: ^0.3.2
+    version: 0.3.2
 
 devDependencies:
   '@nuxt/devtools':
@@ -2983,6 +2986,68 @@ packages:
       - '@vue/composition-api'
       - vue
     dev: true
+
+  /@webassemblyjs/ast@1.11.6:
+    resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.11.6
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+    dev: false
+
+  /@webassemblyjs/floating-point-hex-parser@1.11.6:
+    resolution: {integrity: sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==}
+    dev: false
+
+  /@webassemblyjs/helper-api-error@1.11.6:
+    resolution: {integrity: sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==}
+    dev: false
+
+  /@webassemblyjs/helper-numbers@1.11.6:
+    resolution: {integrity: sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==}
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.11.6
+      '@webassemblyjs/helper-api-error': 1.11.6
+      '@xtuc/long': 4.2.2
+    dev: false
+
+  /@webassemblyjs/helper-wasm-bytecode@1.11.6:
+    resolution: {integrity: sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==}
+    dev: false
+
+  /@webassemblyjs/ieee754@1.11.6:
+    resolution: {integrity: sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==}
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+    dev: false
+
+  /@webassemblyjs/leb128@1.11.6:
+    resolution: {integrity: sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==}
+    dependencies:
+      '@xtuc/long': 4.2.2
+    dev: false
+
+  /@webassemblyjs/utf8@1.11.6:
+    resolution: {integrity: sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==}
+    dev: false
+
+  /@webassemblyjs/wasm-parser@1.11.6:
+    resolution: {integrity: sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==}
+    dependencies:
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/helper-api-error': 1.11.6
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.6
+      '@webassemblyjs/ieee754': 1.11.6
+      '@webassemblyjs/leb128': 1.11.6
+      '@webassemblyjs/utf8': 1.11.6
+    dev: false
+
+  /@xtuc/ieee754@1.2.0:
+    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+    dev: false
+
+  /@xtuc/long@4.2.2:
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+    dev: false
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -10201,6 +10266,15 @@ packages:
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.6.1
 
+  /unplugin@1.6.0:
+    resolution: {integrity: sha512-BfJEpWBu3aE/AyHx8VaNE/WgouoQxgH9baAiH82JjX8cqVyi3uJQstqwD5J+SZxIK326SZIhsSZlALXVBCknTQ==}
+    dependencies:
+      acorn: 8.11.2
+      chokidar: 3.5.3
+      webpack-sources: 3.2.3
+      webpack-virtual-modules: 0.6.1
+    dev: false
+
   /unstorage@1.10.1:
     resolution: {integrity: sha512-rWQvLRfZNBpF+x8D3/gda5nUCQL2PgXy2jNG4U7/Rc9BGEv9+CAJd0YyGCROUBKs9v49Hg8huw3aih5Bf5TAVw==}
     peerDependencies:
@@ -10284,6 +10358,16 @@ packages:
       scule: 1.1.1
     transitivePeerDependencies:
       - supports-color
+
+  /unwasm@0.3.2:
+    resolution: {integrity: sha512-GGgW8Fo+16UBklAQx+n3Vze2E8xr8jkOPXzXVh1Zdfkre9yrgFacfChQoK5fdZt5XtpS+4I/xmLL0ujiOIkU5w==}
+    dependencies:
+      '@webassemblyjs/wasm-parser': 1.11.6
+      magic-string: 0.30.5
+      mlly: 1.4.2
+      pathe: 1.1.1
+      unplugin: 1.6.0
+    dev: false
 
   /update-browserslist-db@1.0.13(browserslist@4.22.2):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}

--- a/src/module.ts
+++ b/src/module.ts
@@ -69,7 +69,7 @@ export default defineNuxtModule<ModuleOptions>({
       // Enable unwasm for shikiji
       nuxt.hook('ready', () => {
         const nitro = useNitro()
-        if (!nitro.options.experimental.wasm) {
+        if (!nitro.options.experimental?.wasm) {
           nitro.options.externals = nitro.options.externals || {}
           nitro.options.externals.inline = nitro.options.externals.inline || []
           nitro.options.externals.inline.push(id => id.endsWith('.wasm'))

--- a/src/runtime/shiki/event-handler.ts
+++ b/src/runtime/shiki/event-handler.ts
@@ -7,16 +7,11 @@ import { useRuntimeConfig } from '#imports'
 export default lazyEventHandler(async () => {
   const { highlight } = useRuntimeConfig().mdc
 
-  try {
-    // try loading `.wasm` directly, for cloudflare workers
-    // @ts-expect-error
-    const wasm = await import('shikiji/onig.wasm').then(r => r.default)
-    await loadWasm(async obj => WebAssembly.instantiate(wasm, obj))
-  }
-  catch {
-    // otherwise fallback to base64 inlined wasm
-    await loadWasm({ data: await import('shikiji/wasm').then(r => r.getWasmInlined()).then(r => r.data) })
-  }
+  await loadWasm((imports) =>
+    import('shikiji/onig.wasm' as string)
+      .then((mod: any) => mod.default(imports))
+      .then((exports) => ({ exports }))
+  )
 
   const shiki = useShikiHighlighter(highlight)
 


### PR DESCRIPTION
Currently, the MDC module enables an experimental feature of nitro for wasm which will change its behavior in the next minor release.

This PR directly adds [unjs/unwasm](https://github.com/unjs/unwasm) plugin + additional patches to replicate the latest implementation of nitro.

Notes:
- This patch is essential to be released before Nitro Minor to avoid breaking current users
- I don't expect significant API changes for unwasm binding and nitro but there is still a chance and until then we need to keep it in sync so please have an eye on upstream @farnabaz 
- Users implicitly getting opted-in to wasm experiment, should be fine with this but if they somehow manually enable `experimental.wasm`, they need to make sure to use latest nitro/nightly 