### PR TITLE
fix: remove `is-buffer` from optimize deps

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -53,7 +53,7 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     nuxt.hook('vite:extendConfig', (viteConfig) => {
-      const optimizeList = ['is-buffer', 'debug', 'flat', 'node-emoji', 'extend', 'hast-util-raw']
+      const optimizeList = ['debug', 'flat', 'node-emoji', 'extend', 'hast-util-raw']
 
       viteConfig.optimizeDeps ||= {}
       viteConfig.optimizeDeps.include ||= []


### PR DESCRIPTION
resolves #121

Currently, few packages are specified in the optimize list: https://github.com/nuxt-modules/mdc/blob/main/src/module.ts#L56

Most of them work only based on implicit hoisted dependencies that install them. Now `is-buffer` is not used or installed by any sub-dependency and causes this issue. It should be removed.

For others `['debug', 'flat', 'node-emoji', 'extend', 'hast-util-raw']` most of them are fragile. `flat` is for example only used by c12 and another random package. As a later solution if you don't prefer to explicitly list them, we might try to resolve them and remove if failed. (could be also a protection logic in nuxt core https://github.com/nuxt/nuxt/issues/24927 /cc @danielroe wdyt?)

Also as a best practice, I highly recommend (I beg you!) please specify any kind of dependency that a module would want explicitly in `dependencies`. It can contribute to solving many of DX issues and hoisting issues.  



