### PR TITLE
feat: add more default highlight langs

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -4,7 +4,24 @@ import type { ModuleOptions } from './types'
 import { defu } from 'defu'
 import { registerMDCSlotTransformer } from './utils/vue-mdc-slot'
 import { resolve } from 'pathe'
+import type { BundledLanguage } from 'shiki'
 import * as templates from './templates'
+
+export const DefaultHighlightLangs: BundledLanguage[] = [
+  'js',
+  'jsx',
+  'json',
+  'ts',
+  'tsx',
+  'vue',
+  'css',
+  'html',
+  'vue',
+  'bash',
+  'md',
+  'mdc',
+  'yaml'
+]
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {
@@ -223,15 +240,7 @@ function resolveOptions(options: ModuleOptions) {
       default: 'github-light',
       dark: 'github-dark'
     }
-    options.highlight.langs ||= [
-      'js',
-      'ts',
-      'vue',
-      'css',
-      'html',
-      'vue',
-      'shell'
-    ]
+    options.highlight.langs ||= DefaultHighlightLangs
 
     if (options.highlight.preload) {
       options.highlight.langs.push(...options.highlight.preload as any || [])

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,7 @@ export interface ModuleOptions {
      *
      * Unlike the `preload` option, when this option is provided, it will override the default languages.
      *
-     * @default ['js','ts','vue','css','html','vue','shell']
+     * @default ['js','jsx','json','ts','tsx','vue','css','html','vue','bash','md','mdc','yaml']
      */
     langs?: (BundledLanguage | LanguageRegistration)[]
 


### PR DESCRIPTION
Include `md`, `mdc`, `yaml`, `tsx`, `jsx` into the default langs to make it easier to use. For ppl who care about the bundle size and not using all the langs, they can always override this array to provide custom list.