### PR TITLE
fix: strip non-word-chars from library import name

### DIFF
--- a/src/templates/mdc-imports.ts
+++ b/src/templates/mdc-imports.ts
@@ -30,11 +30,12 @@ function processUnistPlugins(plugins: Record<string, UnistPlugin>) {
   const imports: string[] = []
   const definitions: string[] = []
   Object.entries(plugins).forEach(([name, plugin]) => {
-    imports.push(`import ${pascalCase(name)} from '${plugin.src || name}'`)
+    const instanceName = pascalCase(name).replace(/\W/g, '')
+    imports.push(`import ${instanceName} from '${plugin.src || name}'`)
     if (Object.keys(plugin).length) {
-      definitions.push(`  '${name}': { instance: ${pascalCase(name)}, options: ${JSON.stringify(plugin.options || plugin)} },`)
+      definitions.push(`  '${name}': { instance: ${instanceName}, options: ${JSON.stringify(plugin.options || plugin)} },`)
     } else {
-      definitions.push(`  '${name}': { instance: ${pascalCase(name)} },`)
+      definitions.push(`  '${name}': { instance: ${instanceName} },`)
     }
   })
 


### PR DESCRIPTION
fixes nuxt/content#2542

[Scule](https://github.com/unjs/scule) seems to not strip non-word-chars on conversion (except for [probably `['-', '_', '/', '.']`](https://github.com/unjs/scule?tab=readme-ov-file#splitbycasestr-splitters)).
So the `@` character is left as the start of an import name.

Should this maybe be changed in Scule too?

The replacement could also be done before passing the string to Scule, if preferred.

I haven't tested this properly, but as far as I can see, this should be the proper fix.