### PR TITLE
fix: prepend import names with underscore

### DIFF
--- a/src/templates/mdc-imports.ts
+++ b/src/templates/mdc-imports.ts
@@ -30,7 +30,7 @@ function processUnistPlugins(plugins: Record<string, UnistPlugin>) {
   const imports: string[] = []
   const definitions: string[] = []
   Object.entries(plugins).forEach(([name, plugin]) => {
-    const instanceName = pascalCase(name).replace(/\W/g, '')
+    const instanceName = `_${pascalCase(name).replace(/\W/g, '')}`
     imports.push(`import ${instanceName} from '${plugin.src || name}'`)
     if (Object.keys(plugin).length) {
       definitions.push(`  '${name}': { instance: ${instanceName}, options: ${JSON.stringify(plugin.options || plugin)} },`)


### PR DESCRIPTION
Follow up to #142

Prepends import names with an underscore to prevent numbers from being the leading character, which would result in an invalid variable name.

It does prevent name conflicts, as it does not just remove the numbers from the name:
- `1abc` → `_1abc` instead of `abc`
- `2abc` → `_2abc` instead of `abc`

There could still be package conflicts:
- `@name/pkg` → `_namePkg`
- `name-pkg` → `_NamePkg`

Okay... bad example for pascal case... but you see the point...