### PR TITLE
build: exports types

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,22 @@
       "import": "./dist/config.mjs",
       "require": "./dist/config.cjs"
     },
-    "./runtime": "./dist/runtime/index.mjs",
-    "./dist/runtime": "./dist/runtime/index.mjs",
-    "./runtime/*": "./dist/runtime/*.mjs",
-    "./dist/runtime/*": "./dist/runtime/*.mjs"
+    "./runtime": {
+      "types": "./dist/runtime/index.d.ts",
+      "import": "./dist/runtime/index.mjs"
+    },
+    "./dist/runtime": {
+      "types": "./dist/runtime/index.d.ts",
+      "import": "./dist/runtime/index.mjs"
+    },
+    "./runtime/*": {
+      "types": "./dist/runtime/*.d.ts",
+      "import": "./dist/runtime/*.mjs"
+    },
+    "./dist/runtime/*": {
+      "types": "./dist/runtime/*.d.ts",
+      "import": "./dist/runtime/*.mjs"
+    }
   },
   "main": "./dist/module.cjs",
   "types": "./dist/types.d.ts",


### PR DESCRIPTION
this PR add types to the exports object for the package.json to avoid issue when this used.

fix #88 