### PR TITLE
feat: use mdcrenderer component and parsemarkdown util outside nuxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,8 @@ Since you're not using Nuxt, you'll need to stub the module's imports in your Vu
 Create a new file in your Vue project's root directory, such as `stub-mdc-imports.js`, and add the following content:
 
 ```ts
-export const useRoute = undefined
-export const useRuntimeConfig = undefined
+// stub-mdc-imports.js
+export default {}
 ```
 
 Next, update your Vue project's Vite config file (e.g. `vite.config.ts`) to alias the module's imports to the stub file. For example:

--- a/README.md
+++ b/README.md
@@ -297,10 +297,8 @@ import path from 'path'
 export default defineConfig({
   resolve: {
     alias: {
-      '#imports': path.resolve(__dirname, './stub-mdc-imports.js'),
       '#mdc-imports': path.resolve(__dirname, './stub-mdc-imports.js'),
-      '#mdc-configs': path.resolve(__dirname, './stub-mdc-imports.js'),
-      '#mdc-highlighter': path.resolve(__dirname, './stub-mdc-imports.js'),
+      '#mdc-configs': path.resolve(__dirname, './stub-mdc-imports.js')
     }
   }
 })
@@ -348,7 +346,7 @@ onBeforeMount(async () => {
   ast.value = await parseMarkdown(md, {
     rehype: {
       plugins: {
-        shikiji: {
+        highlight: {
           instance: rehypeHighlight,
           options: {
             theme: 'material-theme-palenight',

--- a/README.md
+++ b/README.md
@@ -312,9 +312,14 @@ Next, import the necessary package exports into your host project's Vue componen
 
 ```vue
 <script setup lang="ts">
-import { onBeforeMount, ref } from 'vue'
 // Import package exports
-import { MDCRenderer, parseMarkdown, rehypeHighlight, createShikiHighlighter } from '@nuxtjs/mdc/runtime'
+import {
+  MDCRenderer,
+  parseMarkdown,
+  rehypeHighlight,
+  createShikiHighlighter,
+} from '@nuxtjs/mdc/runtime'
+
 // Import desired shiki themes and languages
 import MaterialThemePalenight from 'shiki/themes/material-theme-palenight.mjs'
 import HtmlLang from 'shiki/langs/html.mjs'
@@ -323,6 +328,9 @@ import TsLang from 'shiki/langs/typescript.mjs'
 import VueLang from 'shiki/langs/vue.mjs'
 import ScssLang from 'shiki/langs/scss.mjs'
 import YamlLang from 'shiki/langs/yaml.mjs'
+
+// Vue imports
+import { onBeforeMount, ref } from 'vue'
 
 const md = `
 # Example

--- a/src/module.ts
+++ b/src/module.ts
@@ -93,7 +93,7 @@ export default defineNuxtModule<ModuleOptions>({
 
       options.rehypePlugins ||= {}
       options.rehypePlugins.highlight ||= {}
-      options.rehypePlugins.highlight.src ||= await resolver.resolvePath('./runtime/highlighter/rehype')
+      options.rehypePlugins.highlight.src ||= await resolver.resolvePath('./runtime/highlighter/rehype-nuxt')
       options.rehypePlugins.highlight.options ||= {}
     }
 

--- a/src/runtime/components/MDCRenderer.vue
+++ b/src/runtime/components/MDCRenderer.vue
@@ -62,11 +62,12 @@ export default defineComponent({
     }
   },
   async setup (props) {
-    const { mdc } = useRuntimeConfig().public
+    // TODO: Is there a better fallback here?
+    const { mdc } = typeof useRuntimeConfig === 'function' ? useRuntimeConfig().public : { mdc: {} as Record<string, any> }
 
     const tags = {
-      ...(mdc.components.prose && props.prose !== false ? proseComponentMap : {}),
-      ...mdc.components.map,
+      ...(mdc.components?.prose && props.prose !== false ? proseComponentMap : {}),
+      ...mdc.components?.map || {},
       ...toRaw(props.data?.mdc?.components || {}),
       ...props.components
     }
@@ -144,7 +145,7 @@ function renderNode (node: MDCNode, h: CreateElement, documentMeta: MDCData, par
 function renderBinding (node: MDCElement, h: CreateElement, documentMeta: MDCData, parentScope: any = {}): VNode {
   const data = {
     ...parentScope,
-    $route: () => useRoute(),
+    $route: () => typeof useRoute === 'function' ? useRoute() : undefined,
     $document: documentMeta,
     $doc: documentMeta
   }

--- a/src/runtime/components/prose/ProseScript.vue
+++ b/src/runtime/components/prose/ProseScript.vue
@@ -5,13 +5,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-
 defineProps({
   src: {
     type: String,
     default: ''
   }
 })
-const isDev = computed(() => typeof process !== 'undefined' && process.dev)
+const isDev = import.meta.env
 </script>

--- a/src/runtime/components/prose/ProseScript.vue
+++ b/src/runtime/components/prose/ProseScript.vue
@@ -13,5 +13,5 @@ defineProps({
     default: ''
   }
 })
-const isDev = computed(() => process.dev)
+const isDev = computed(() => typeof process !== 'undefined' && process.dev)
 </script>

--- a/src/runtime/highlighter/rehype-nuxt.ts
+++ b/src/runtime/highlighter/rehype-nuxt.ts
@@ -5,7 +5,7 @@ const defaults: RehypeHighlightOption = {
   theme: {},
   async highlighter(code, lang, theme, options) {
     try {
-      if (typeof process !== 'undefined' && process.browser && window.sessionStorage.getItem('mdc-shiki-highlighter') === 'browser') {
+      if (process.browser && window.sessionStorage.getItem('mdc-shiki-highlighter') === 'browser') {
         return import('#mdc-highlighter').then(h => h.default(code, lang, theme, options)).catch(() => ({}))
       }
 
@@ -18,7 +18,7 @@ const defaults: RehypeHighlightOption = {
         }
       })
     } catch (e: any) {
-      if (typeof process !== 'undefined' && process.browser && e?.response?.status === 404) {
+      if (process.browser && e?.response?.status === 404) {
         window.sessionStorage.setItem('mdc-shiki-highlighter', 'browser')
         return this.highlighter?.(code, lang, theme, options)!
       }
@@ -27,11 +27,15 @@ const defaults: RehypeHighlightOption = {
     return Promise.resolve({ tree: [{ type: 'text', value: code }], className: '', style: '' } as HighlightResult)
   }
 }
-
 export default rehypeHighlight
 
 export function rehypeHighlight(opts: Partial<RehypeHighlightOption> = {}) {
   const options = { ...defaults, ...opts } as RehypeHighlightOption
+
+  if (typeof options.highlighter !== 'function') {
+    options.highlighter = defaults.highlighter
+  }
+
 
   return rehypeHighlightUniversal(options)
 }

--- a/src/runtime/highlighter/rehype-nuxt.ts
+++ b/src/runtime/highlighter/rehype-nuxt.ts
@@ -1,0 +1,37 @@
+import { rehypeHighlight as rehypeHighlightUniversal, type RehypeHighlightOption } from './rehype'
+import type { HighlightResult } from './types'
+
+const defaults: RehypeHighlightOption = {
+  theme: {},
+  async highlighter(code, lang, theme, options) {
+    try {
+      if (typeof process !== 'undefined' && process.browser && window.sessionStorage.getItem('mdc-shiki-highlighter') === 'browser') {
+        return import('#mdc-highlighter').then(h => h.default(code, lang, theme, options)).catch(() => ({}))
+      }
+
+      return await $fetch('/api/_mdc/highlight', {
+        params: {
+          code,
+          lang,
+          theme: JSON.stringify(theme),
+          options: JSON.stringify(options)
+        }
+      })
+    } catch (e: any) {
+      if (typeof process !== 'undefined' && process.browser && e?.response?.status === 404) {
+        window.sessionStorage.setItem('mdc-shiki-highlighter', 'browser')
+        return this.highlighter?.(code, lang, theme, options)!
+      }
+    }
+
+    return Promise.resolve({ tree: [{ type: 'text', value: code }], className: '', style: '' } as HighlightResult)
+  }
+}
+
+export default rehypeHighlight
+
+export function rehypeHighlight(opts: Partial<RehypeHighlightOption> = {}) {
+  const options = { ...defaults, ...opts } as RehypeHighlightOption
+
+  return rehypeHighlightUniversal(options)
+}

--- a/src/runtime/highlighter/rehype.ts
+++ b/src/runtime/highlighter/rehype.ts
@@ -5,7 +5,7 @@ import type { Highlighter, MdcThemeOptions } from './types'
 
 export interface RehypeHighlightOption {
   theme?: MdcThemeOptions
-  highlighter: Highlighter
+  highlighter?: Highlighter
 }
 
 export default rehypeHighlight

--- a/src/runtime/highlighter/rehype.ts
+++ b/src/runtime/highlighter/rehype.ts
@@ -11,11 +11,11 @@ export interface RehypeHighlightOption {
 const defaults: RehypeHighlightOption = {
   theme: {},
   async highlighter(code, lang, theme, options) {
-    if (process.browser && window.sessionStorage.getItem('mdc-shiki-highlighter') === 'browser') {
-      return import('#mdc-highlighter').then(h => h.default(code, lang, theme, options))
-    }
-
     try {
+      if (typeof process !== 'undefined' && process.browser && window.sessionStorage.getItem('mdc-shiki-highlighter') === 'browser') {
+        return import('#mdc-highlighter').then(h => h.default(code, lang, theme, options)).catch(() => ({}))
+      }
+
       return await $fetch('/api/_mdc/highlight', {
         params: {
           code,
@@ -25,7 +25,7 @@ const defaults: RehypeHighlightOption = {
         }
       })
     } catch (e: any) {
-      if (process.browser && e?.response?.status === 404) {
+      if (typeof process !== 'undefined' && process.browser && e?.response?.status === 404) {
         window.sessionStorage.setItem('mdc-shiki-highlighter', 'browser')
         return this.highlighter?.(code, lang, theme, options)!
       }

--- a/src/runtime/highlighter/rehype.ts
+++ b/src/runtime/highlighter/rehype.ts
@@ -1,44 +1,17 @@
 import type { Root, Element } from 'hast'
 import { visit } from 'unist-util-visit'
 import { toString } from 'hast-util-to-string'
-import type { HighlightResult, Highlighter, MdcThemeOptions } from './types'
+import type { Highlighter, MdcThemeOptions } from './types'
 
 export interface RehypeHighlightOption {
   theme?: MdcThemeOptions
-  highlighter?: Highlighter
-}
-
-const defaults: RehypeHighlightOption = {
-  theme: {},
-  async highlighter(code, lang, theme, options) {
-    try {
-      if (typeof process !== 'undefined' && process.browser && window.sessionStorage.getItem('mdc-shiki-highlighter') === 'browser') {
-        return import('#mdc-highlighter').then(h => h.default(code, lang, theme, options)).catch(() => ({}))
-      }
-
-      return await $fetch('/api/_mdc/highlight', {
-        params: {
-          code,
-          lang,
-          theme: JSON.stringify(theme),
-          options: JSON.stringify(options)
-        }
-      })
-    } catch (e: any) {
-      if (typeof process !== 'undefined' && process.browser && e?.response?.status === 404) {
-        window.sessionStorage.setItem('mdc-shiki-highlighter', 'browser')
-        return this.highlighter?.(code, lang, theme, options)!
-      }
-    }
-
-    return Promise.resolve({ tree: [{ type: 'text', value: code }], className: '', style: '' } as HighlightResult)
-  }
+  highlighter: Highlighter
 }
 
 export default rehypeHighlight
 
-export function rehypeHighlight(opts: RehypeHighlightOption = {}) {
-  const options = { ...defaults, ...opts }
+export function rehypeHighlight(opts: RehypeHighlightOption) {
+  const options = opts
 
   return async (tree: Root) => {
     const tasks: Promise<void>[] = []

--- a/src/runtime/highlighter/shiki.ts
+++ b/src/runtime/highlighter/shiki.ts
@@ -83,7 +83,7 @@ export function createShikiHighlighter({
         await shiki.loadLanguage(bundledLangs[lang])
       }
       else {
-        if (process.dev) {
+        if (typeof process !== 'undefined' && process.dev) {
           console.warn(`[@nuxtjs/mdc] Language "${lang}" is not loaded to the Shiki highlighter, fallback to plain text. Add the language to "mdc.highlight.langs" to fix this.`)
         }
         lang = 'text'
@@ -96,7 +96,7 @@ export function createShikiHighlighter({
           await shiki.loadTheme(bundledThemes[theme])
         }
         else {
-          if (process.dev) {
+          if (typeof process !== 'undefined' && process.dev) {
             console.warn(`[@nuxtjs/mdc] Theme "${theme}" is not loaded to the Shiki highlighter. Add the theme to "mdc.highlight.themes" to fix this.`)
           }
           themesObject[color] = 'none'

--- a/src/runtime/highlighter/shiki.ts
+++ b/src/runtime/highlighter/shiki.ts
@@ -83,7 +83,7 @@ export function createShikiHighlighter({
         await shiki.loadLanguage(bundledLangs[lang])
       }
       else {
-        if (typeof process !== 'undefined' && process.dev) {
+        if (import.meta.env) {
           console.warn(`[@nuxtjs/mdc] Language "${lang}" is not loaded to the Shiki highlighter, fallback to plain text. Add the language to "mdc.highlight.langs" to fix this.`)
         }
         lang = 'text'
@@ -96,7 +96,7 @@ export function createShikiHighlighter({
           await shiki.loadTheme(bundledThemes[theme])
         }
         else {
-          if (typeof process !== 'undefined' && process.dev) {
+          if (import.meta.env) {
             console.warn(`[@nuxtjs/mdc] Theme "${theme}" is not loaded to the Shiki highlighter. Add the theme to "mdc.highlight.themes" to fix this.`)
           }
           themesObject[color] = 'none'

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,2 +1,5 @@
 export { parseMarkdown } from './parser'
+export { rehypeHighlight } from './highlighter/rehype'
+export { createShikiHighlighter } from './highlighter/shiki'
+export { default as MDCRenderer } from './components/MDCRenderer.vue'
 export * from './utils/node'

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,4 +1,4 @@
-export { parseMarkdown } from './parser'
+export { parseMarkdown, createMarkdownParser } from './parser'
 export { rehypeHighlight } from './highlighter/rehype'
 export { createShikiHighlighter } from './highlighter/shiki'
 export { default as MDCRenderer } from './components/MDCRenderer.vue'

--- a/src/runtime/parser/index.ts
+++ b/src/runtime/parser/index.ts
@@ -33,7 +33,7 @@ export const parseMarkdown = async (md: string, inlineOptions: MDCParseOptions =
 
   // TODO: remove the passing in @nuxt/content and then we could remove this line
   if (inlineOptions.highlight != null && inlineOptions.highlight != false && inlineOptions.highlight.highlighter !== undefined && typeof inlineOptions.highlight.highlighter !== 'function') {
-    if (import.meta.dev)
+    if (import.meta?.dev)
       console.warn('[@nuxtjs/mdc] `highlighter` passed to `parseMarkdown` is should be a function, but got ' + JSON.stringify(inlineOptions.highlight.highlighter) + ', ignored.')
     inlineOptions = {
       ...inlineOptions,

--- a/src/runtime/parser/index.ts
+++ b/src/runtime/parser/index.ts
@@ -33,7 +33,7 @@ export const parseMarkdown = async (md: string, inlineOptions: MDCParseOptions =
 
   // TODO: remove the passing in @nuxt/content and then we could remove this line
   if (inlineOptions.highlight != null && inlineOptions.highlight != false && inlineOptions.highlight.highlighter !== undefined && typeof inlineOptions.highlight.highlighter !== 'function') {
-    if (import.meta?.dev)
+    if (import.meta.dev)
       console.warn('[@nuxtjs/mdc] `highlighter` passed to `parseMarkdown` is should be a function, but got ' + JSON.stringify(inlineOptions.highlight.highlighter) + ', ignored.')
     inlineOptions = {
       ...inlineOptions,

--- a/src/runtime/types/parser.ts
+++ b/src/runtime/types/parser.ts
@@ -1,6 +1,8 @@
 import type { Options as RehypeOption } from 'remark-rehype'
 import type { RehypeHighlightOption } from '../highlighter/rehype'
 import type { MdcConfig } from './config'
+import type { MDCData, MDCRoot } from './tree'
+import type { Toc } from './toc'
 
 export interface RemarkPlugin {
   instance?: any
@@ -38,4 +40,11 @@ export interface MDCParseOptions {
    * Inline mdc.config.ts
    */
   configs?: MdcConfig[]
+}
+
+export interface MDCParserResult {
+    data: MDCData,
+    body: MDCRoot,
+    excerpt: MDCRoot | undefined,
+    toc: Toc | undefined
 }

--- a/test/utils/parser.ts
+++ b/test/utils/parser.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest'
 import { parseMarkdown as _parseMarkDown } from '../../src/runtime/parser'
 import type { MDCParseOptions } from '../../src/runtime/types'
-import  { rehypeHighlight } from '../../src/runtime/highlighter/rehype'
+import  { rehypeHighlight } from '../../src/runtime/highlighter/rehype-nuxt'
 import { createShikiHighlighter } from '../../src/runtime/highlighter/shiki'
 
 vi.mock('#mdc-imports', () => {


### PR DESCRIPTION
Allow utilizing the `MDCRenderer.vue` component and `parseMarkdown` utility in a normal Vue app, outside Nuxt. 

I've updated the `@nuxtjs/mdc` module in this PR along with updates to the primary README for usage instructions.

I've also created a [CodeSandbox demo](https://codesandbox.io/p/devbox/mdc-in-vue-vd7thh) by building the package, running `npm pack`, and importing the changes into the sandbox via a local `nuxtjs-mdc-local.tgz` bundle.

![MDCRenderer component rendering markdown and MDC](https://github.com/nuxt-modules/mdc/assets/2229946/77e1809a-e74a-48e0-a3a1-c6d7a8fcfbd2)

Please see the README file in the PR as well as the CodeSandbox for a usage example.

@farnabaz @antfu I'd appreciate some eyes on this; mainly around:

1. Is defining import aliases in the host project's Vite config the best way to get around the Nuxt-specific imports that aren't needed? I don't like the host app having to include the aliases and the stubbed import file, but wasn't sure of another way of getting around Vite choking on the import paths. This is a bit fragile, as if any new imports are added in the future, a host project would have to add more aliases to its Vite config. I thought about refactoring at least these internal `#mdc-*` imports but wasn't sure of the downstream impact. 
2. I have syntax highlighting working by exporting a few of the remark and shiki utils that were previously internal (as @farnabaz and I discussed last week at Vue Amsterdam). Syntax highlighting works via the host project defining it's highlighter via the `createShikiHighlighter` util along with the `rehypeHighlight` and passing it into the `parseMarkdown` utility. This works great in my opinion, but just want to make sure this is good as a long-term solution?
3. I have a TODO question in the fallback interface I'm providing in the `MDCRenderer.vue` setup function.

When merged, this will resolve https://github.com/nuxt-modules/mdc/issues/155.