### PR TITLE
fix: optimise deps with nested config

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -201,7 +201,7 @@ export default defineNuxtModule<ModuleOptions>({
 
       for (const pkg of include) {
         if (!config.optimizeDeps.include.includes(pkg)) {
-          config.optimizeDeps.include.push(pkg)
+          config.optimizeDeps.include.push('@nuxtjs/mdc > ' + pkg)
         }
       }
 


### PR DESCRIPTION
resolves https://github.com/nuxt/content/issues/2381

Vite requires dependencies that are optimised to be installed, but none of these deps will be directly installed by users (or they have to add them, which is a negative user experience). So we can indicate to vite to resolve the dependency from within another dependency that _is_ installed, in this case `@nuxtjs/mdc`...

If the user does _not_ have `@nuxtjs/mdc` (e.g. because nuxt/content is installing it) then we will have to modify these dependencies upstream.... (see linked PR in nuxt/content)