### PR TITLE
feat: use `nuxt-shiki`

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "hast-util-to-string": "^3.0.0",
     "mdast-util-to-hast": "^13.1.0",
     "micromark-util-sanitize-uri": "^2.0.0",
+    "nuxt-shiki": "^0.2.1",
     "ohash": "^1.1.3",
     "parse5": "^7.1.2",
     "pathe": "^1.1.2",
@@ -95,8 +96,7 @@
     "ufo": "^1.4.0",
     "unified": "^11.0.4",
     "unist-builder": "^4.0.0",
-    "unist-util-visit": "^5.0.0",
-    "unwasm": "^0.3.7"
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@nuxt/devtools": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       micromark-util-sanitize-uri:
         specifier: ^2.0.0
         version: 2.0.0
+      nuxt-shiki:
+        specifier: ^0.2.1
+        version: 0.2.1(rollup@3.29.4)
       ohash:
         specifier: ^1.1.3
         version: 1.1.3
@@ -110,9 +113,6 @@ importers:
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
-      unwasm:
-        specifier: ^0.3.7
-        version: 0.3.7
     devDependencies:
       '@nuxt/devtools':
         specifier: latest
@@ -7680,6 +7680,17 @@ packages:
       - vite
       - vue
     dev: true
+
+  /nuxt-shiki@0.2.1(rollup@3.29.4):
+    resolution: {integrity: sha512-LWFgojb3autTMb+kpiwRQLHnM9getFHicWxGWU+UExFTydqm1CGC8oeAcZXweSUG9tm6nkpU/MNcAotCeVmXOg==}
+    dependencies:
+      '@nuxt/kit': 3.10.3(rollup@3.29.4)
+      shiki: 1.1.7
+      unwasm: 0.3.7
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+    dev: false
 
   /nuxt@3.10.3(@types/node@20.11.25)(eslint@8.57.0)(rollup@3.29.4)(typescript@5.3.3)(vite@5.1.4):
     resolution: {integrity: sha512-NchGNiiz9g/ErJAb462W/lpX2NqcXYb9hugySKWvLXNdrjeAPiJ2/7mhgwUSiZA9MpjuQg3saiEajr1zlRIOCg==}

--- a/src/runtime/highlighter/shiki.ts
+++ b/src/runtime/highlighter/shiki.ts
@@ -11,6 +11,7 @@ import {
 import type { MdcConfig } from '../types/config'
 // @ts-expect-error - `nuxt-shiki` is installed by the module.
 import { loadShiki } from '#imports'
+import type { ShikiInstance } from 'nuxt-shiki/dist/runtime/types'
 
 export interface CreateShikiHighlighterOptions {
   /* An array of themes to be loaded initially */
@@ -37,7 +38,7 @@ export function createShikiHighlighter({
   let configs: Promise<MdcConfig[]> | undefined
 
   async function _getShiki() {
-    const shiki = await loadShiki()
+    const shiki = await loadShiki() as ShikiInstance
 
     for await (const config of await getConfigs()) {
       await config.shiki?.setup?.(shiki)

--- a/src/runtime/highlighter/shiki.ts
+++ b/src/runtime/highlighter/shiki.ts
@@ -1,4 +1,4 @@
-import { getHighlighterCore, addClassToHast, isSpecialLang, isSpecialTheme } from 'shiki/core'
+import { addClassToHast, isSpecialLang, isSpecialTheme } from 'shiki/core'
 import type { HighlighterCore, LanguageInput, ShikiTransformer, ThemeInput } from 'shiki'
 import type { Highlighter } from './types'
 import type { Element } from 'hast'
@@ -9,6 +9,8 @@ import {
   transformerNotationHighlight,
 } from '@shikijs/transformers'
 import type { MdcConfig } from '../types/config'
+// @ts-expect-error - `nuxt-shiki` is installed by the module.
+import { loadShiki } from '#imports'
 
 export interface CreateShikiHighlighterOptions {
   /* An array of themes to be loaded initially */
@@ -26,8 +28,6 @@ export interface CreateShikiHighlighterOptions {
 }
 
 export function createShikiHighlighter({
-  langs = [],
-  themes = [],
   bundledLangs = {},
   bundledThemes = {},
   getMdcConfigs,
@@ -37,11 +37,7 @@ export function createShikiHighlighter({
   let configs: Promise<MdcConfig[]> | undefined
 
   async function _getShiki() {
-    const shiki = await getHighlighterCore({
-      langs,
-      themes,
-      loadWasm: () => import('shiki/wasm')
-    })
+    const shiki = await loadShiki()
 
     for await (const config of await getConfigs()) {
       await config.shiki?.setup?.(shiki)


### PR DESCRIPTION
resolves #148

In this PR I added the module `nuxt-shiki`. 

Which controls the main core level to shiki like loading wasm binary, exposes functions for other projects to then consume in there projects.

cc:// @Atinux  @pi0 