### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,7 @@ Learn more about the MDC syntax on https://content.nuxtjs.org/guide/writing/mdc
 ## Install
 
 ```bash
-# Using npm
-npm install --save-dev @nuxtjs/mdc
-
-# Using yarn
-yarn add --dev @nuxtjs/mdc
-
-# Using pnpm
-pnpm add --dev @nuxtjs/mdc
+npx nuxi@latest module add mdc
 ```
 
 Then, add `@nuxtjs/mdc` to the modules section of your `nuxt.config.ts`

--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -10,18 +10,9 @@ MDC stands for Markdown Components. This syntax supercharges regular Markdown to
 ## Setup
 
 Add the `@nuxtjs/mdc` dependency to your project:
-
-::code-group
-```bash [Yarn]
-yarn add --dev @nuxtjs/mdc
+```bash
+npx nuxi@latest module add mdc
 ```
-```bash [NPM]
-npm install --save-dev @nuxtjs/mdc
-```
-```bash [PNPM]
-pnpm i --save-dev @nuxtjs/mdc
-```
-::
 
 Then, add `@nuxtjs/mdc` to the modules section of your `nuxt.config.ts`
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
