### PR TITLE
fix(types): Add `useNuxtImage` type into runtime config

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -253,6 +253,7 @@ declare module '@nuxt/schema' {
         map: Record<string, string>
       }
       headings: ModuleOptions['headings']
+      useNuxtImage?: boolean;
     }
   }
 


### PR DESCRIPTION
A type issue in the newly released version 0.7.0 and introduced by #180 seems to be that the runtime config type wasn't updated to include the `useNuxtImage` type which is causing `nuxi typecheck` to fail with the error:

```bash
node_modules/.pnpm/@nuxtjs+mdc@0.7.0_rollup@4.17.2/node_modules/@nuxtjs/mdc/dist/runtime/components/prose/ProseImg.vue:15:52 - error TS2339: Property 'useNuxtImage' does not exist on type '{ components: { prose: boolean; map: Record<string, string>; }; headings: { anchorLinks?: { h1?: boolean | undefined; h2?: boolean | undefined; h3?: boolean | undefined; h4?: boolean | undefined; h5?: boolean | undefined; h6?: boolean | undefined; } | undefined; } | undefined; }'.

15 const imgComponent = useRuntimeConfig().public.mdc.useNuxtImage ? resolveComponent('NuxtImg') : 'img'
                                                      ~~~~~~~~~~~~


Found 1 error in node_modules/.pnpm/@nuxtjs+mdc@0.7.0_rollup@4.17.2/node_modules/@nuxtjs/mdc/dist/runtime/components/prose/ProseImg.vue:15
```

I have verified this change which I originally applied via pnpm patching:

```patch
diff --git a/dist/module.d.mts b/dist/module.d.mts
index a7d60f544b012898715d82b430df1ac07faab004..3619a534a9f13f5f3c4835c80b6477648e278bc9 100644
--- a/dist/module.d.mts
+++ b/dist/module.d.mts
@@ -83,6 +83,7 @@ declare module '@nuxt/schema' {
                 map: Record<string, string>;
             };
             headings: ModuleOptions['headings'];
+            useNuxtImage?: boolean;
         };
     }
     interface ConfigSchema {
diff --git a/dist/module.d.ts b/dist/module.d.ts
index 581941eaa560059fc5abce4329f0057ee5678a83..dfd089e203ad21631d2a78da69ba36811570fa3b 100644
--- a/dist/module.d.ts
+++ b/dist/module.d.ts
@@ -82,6 +82,7 @@ declare module '@nuxt/schema' {
                 prose: boolean;
                 map: Record<string, string>;
             };
+            useNuxtImage?: boolean;
             headings: ModuleOptions['headings'];
         };
     }
```

