### PR TITLE
fix double entry for "vue" highlight language

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -17,7 +17,6 @@ export const DefaultHighlightLangs: BundledLanguage[] = [
   'vue',
   'css',
   'html',
-  'vue',
   'bash',
   'md',
   'mdc',

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,7 @@ export interface ModuleOptions {
      *
      * Unlike the `preload` option, when this option is provided, it will override the default languages.
      *
-     * @default ['js','jsx','json','ts','tsx','vue','css','html','vue','bash','md','mdc','yaml']
+     * @default ['js','jsx','json','ts','tsx','vue','css','html','bash','md','mdc','yaml']
      */
     langs?: (BundledLanguage | LanguageRegistration)[]
 


### PR DESCRIPTION
There is a double entry for "vue"in supported highlight languages.

This PR fixes this.