### PR TITLE
fix: add `false` as accepted value for `headings.anchorLinks` option

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,7 @@ export interface ModuleOptions {
   headings?: {
     anchorLinks?: {
       [heading in 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6']?: boolean
-    }
+    } | false
   }
 
   keepComments?: boolean


### PR DESCRIPTION
Adding `false` as accepted value for `headings.anchorLinks` option, as discussed here: #203 