### PR TITLE
fix: add `true` as accepted value for `headings.anchorLinks` option

### DIFF
--- a/src/runtime/components/prose/ProseH1.vue
+++ b/src/runtime/components/prose/ProseH1.vue
@@ -16,5 +16,5 @@ import { computed, useRuntimeConfig } from '#imports'
 const props = defineProps<{ id?: string }>()
 
 const { headings } = useRuntimeConfig().public.mdc
-const generate = computed(() => props.id && headings?.anchorLinks?.h1)
+const generate = computed(() => props.id && (headings?.anchorLinks === true || headings?.anchorLinks?.h1))
 </script>

--- a/src/runtime/components/prose/ProseH2.vue
+++ b/src/runtime/components/prose/ProseH2.vue
@@ -16,5 +16,5 @@ import { computed, useRuntimeConfig } from '#imports'
 const props = defineProps<{ id?: string }>()
 
 const { headings } = useRuntimeConfig().public.mdc
-const generate = computed(() => props.id && headings?.anchorLinks?.h2)
+const generate = computed(() => props.id && (headings?.anchorLinks === true || headings?.anchorLinks?.h2))
 </script>

--- a/src/runtime/components/prose/ProseH3.vue
+++ b/src/runtime/components/prose/ProseH3.vue
@@ -16,5 +16,5 @@ import { computed, useRuntimeConfig } from '#imports'
 const props = defineProps<{ id?: string }>()
 
 const { headings } = useRuntimeConfig().public.mdc
-const generate = computed(() => props.id && headings?.anchorLinks?.h3)
+const generate = computed(() => props.id && (headings?.anchorLinks === true || headings?.anchorLinks?.h3))
 </script>

--- a/src/runtime/components/prose/ProseH4.vue
+++ b/src/runtime/components/prose/ProseH4.vue
@@ -16,5 +16,5 @@ import { computed, useRuntimeConfig } from '#imports'
 const props = defineProps<{ id?: string }>()
 
 const { headings } = useRuntimeConfig().public.mdc
-const generate = computed(() => props.id && headings?.anchorLinks?.h4)
+const generate = computed(() => props.id && (headings?.anchorLinks === true || headings?.anchorLinks?.h4))
 </script>

--- a/src/runtime/components/prose/ProseH5.vue
+++ b/src/runtime/components/prose/ProseH5.vue
@@ -16,5 +16,5 @@ import { computed, useRuntimeConfig } from '#imports'
 const props = defineProps<{ id?: string }>()
 
 const { headings } = useRuntimeConfig().public.mdc
-const generate = computed(() => props.id && headings?.anchorLinks?.h5)
+const generate = computed(() => props.id && (headings?.anchorLinks === true || headings?.anchorLinks?.h5))
 </script>

--- a/src/runtime/components/prose/ProseH6.vue
+++ b/src/runtime/components/prose/ProseH6.vue
@@ -16,5 +16,5 @@ import { computed, useRuntimeConfig } from '#imports'
 const props = defineProps<{ id?: string }>()
 
 const { headings } = useRuntimeConfig().public.mdc
-const generate = computed(() => props.id && headings?.anchorLinks?.h6)
+const generate = computed(() => props.id && (headings?.anchorLinks === true || headings?.anchorLinks?.h6))
 </script>

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,7 @@ export interface ModuleOptions {
   headings?: {
     anchorLinks?: {
       [heading in 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6']?: boolean
-    } | false
+    } | boolean
   }
 
   keepComments?: boolean


### PR DESCRIPTION
Simply add `true` as an accepted value for `headings.anchorLinks` option.

This PR is complementary to #206 and if accepted it will close #203.

I tested this both with `pnpm test` and manually in the playground, everything seems to be working as expected, but please take a moment to check if the implementation is ok for you.

