### PR TITLE
fix(wasm): include cloudflare-module preset

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -123,7 +123,7 @@ export default defineNuxtModule<ModuleOptions>({
     const nitroPreset = nuxt.options.nitro.preset as string || process.env.NITRO_PRESET || process.env.SERVER_PRESET || ''
     const useWasmAssets = !nuxt.options.dev && (
       !!nuxt.options.nitro.experimental?.wasm
-      || ['cloudflare-pages', 'cloudflare'].includes(nitroPreset)
+      || ['cloudflare-pages', 'cloudflare-module', 'cloudflare'].includes(nitroPreset)
     )
     registerTemplate({
       filename: 'mdc-highlighter.mjs',


### PR DESCRIPTION
Add the `cloudflare-module` [Nitro preset](https://nitro.unjs.io/deploy/providers/cloudflare#cloudflare-module-workers) to the list of presets to check for to determine whether `useWasmAssets` should return `true`.