### PR TITLE
fix(build): resolve runtime/**/*.js files and prose header types

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     },
     "./runtime": {
       "types": "./dist/runtime/index.d.ts",
-      "import": "./dist/runtime/index.mjs"
+      "import": "./dist/runtime/index.js"
     },
     "./dist/runtime": {
       "types": "./dist/runtime/index.d.ts",
-      "import": "./dist/runtime/index.mjs"
+      "import": "./dist/runtime/index.js"
     },
     "./runtime/components/*": {
       "types": "./dist/runtime/components/*.d.ts",
@@ -34,11 +34,11 @@
     },
     "./runtime/*": {
       "types": "./dist/runtime/*.d.ts",
-      "import": "./dist/runtime/*.mjs"
+      "import": "./dist/runtime/*.js"
     },
     "./dist/runtime/*": {
       "types": "./dist/runtime/*.d.ts",
-      "import": "./dist/runtime/*.mjs"
+      "import": "./dist/runtime/*.js"
     }
   },
   "main": "./dist/module.cjs",

--- a/src/module.ts
+++ b/src/module.ts
@@ -128,7 +128,7 @@ export default defineNuxtModule<ModuleOptions>({
       filename: 'mdc-highlighter.mjs',
       getContents: templates.mdcHighlighter,
       options: {
-        shikiPath: resolver.resolve('../dist/runtime/highlighter/shiki'),
+        shikiPath: resolver.resolve('../dist/runtime/highlighter/shiki.js'),
         options: options.highlight,
         useWasmAssets
       }

--- a/src/runtime/components/prose/ProseH1.vue
+++ b/src/runtime/components/prose/ProseH1.vue
@@ -16,5 +16,5 @@ import { computed, useRuntimeConfig } from '#imports'
 const props = defineProps<{ id?: string }>()
 
 const { headings } = useRuntimeConfig().public.mdc
-const generate = computed(() => props.id && (headings?.anchorLinks === true || (typeof headings?.anchorLinks === 'object' && headings?.anchorLinks?.h1)))
+const generate = computed(() => props.id && ((typeof headings?.anchorLinks === 'boolean' && headings?.anchorLinks === true) || (typeof headings?.anchorLinks === 'object' && headings?.anchorLinks?.h1)))
 </script>

--- a/src/runtime/components/prose/ProseH2.vue
+++ b/src/runtime/components/prose/ProseH2.vue
@@ -16,5 +16,5 @@ import { computed, useRuntimeConfig } from '#imports'
 const props = defineProps<{ id?: string }>()
 
 const { headings } = useRuntimeConfig().public.mdc
-const generate = computed(() => props.id && (headings?.anchorLinks === true || (typeof headings?.anchorLinks === 'object' && headings?.anchorLinks?.h2)))
+const generate = computed(() => props.id && ((typeof headings?.anchorLinks === 'boolean' && headings?.anchorLinks === true) || (typeof headings?.anchorLinks === 'object' && headings?.anchorLinks?.h2)))
 </script>

--- a/src/runtime/components/prose/ProseH3.vue
+++ b/src/runtime/components/prose/ProseH3.vue
@@ -16,5 +16,5 @@ import { computed, useRuntimeConfig } from '#imports'
 const props = defineProps<{ id?: string }>()
 
 const { headings } = useRuntimeConfig().public.mdc
-const generate = computed(() => props.id && (headings?.anchorLinks === true || (typeof headings?.anchorLinks === 'object' && headings?.anchorLinks?.h3)))
+const generate = computed(() => props.id && ((typeof headings?.anchorLinks === 'boolean' && headings?.anchorLinks === true) || (typeof headings?.anchorLinks === 'object' && headings?.anchorLinks?.h3)))
 </script>

--- a/src/runtime/components/prose/ProseH4.vue
+++ b/src/runtime/components/prose/ProseH4.vue
@@ -16,5 +16,5 @@ import { computed, useRuntimeConfig } from '#imports'
 const props = defineProps<{ id?: string }>()
 
 const { headings } = useRuntimeConfig().public.mdc
-const generate = computed(() => props.id && (headings?.anchorLinks === true || (typeof headings?.anchorLinks === 'object' && headings?.anchorLinks?.h4)))
+const generate = computed(() => props.id && ((typeof headings?.anchorLinks === 'boolean' && headings?.anchorLinks === true) || (typeof headings?.anchorLinks === 'object' && headings?.anchorLinks?.h4)))
 </script>

--- a/src/runtime/components/prose/ProseH5.vue
+++ b/src/runtime/components/prose/ProseH5.vue
@@ -16,5 +16,5 @@ import { computed, useRuntimeConfig } from '#imports'
 const props = defineProps<{ id?: string }>()
 
 const { headings } = useRuntimeConfig().public.mdc
-const generate = computed(() => props.id && (headings?.anchorLinks === true || (typeof headings?.anchorLinks === 'object' && headings?.anchorLinks?.h5)))
+const generate = computed(() => props.id && ((typeof headings?.anchorLinks === 'boolean' && headings?.anchorLinks === true) || (typeof headings?.anchorLinks === 'object' && headings?.anchorLinks?.h5)))
 </script>

--- a/src/runtime/components/prose/ProseH6.vue
+++ b/src/runtime/components/prose/ProseH6.vue
@@ -16,5 +16,5 @@ import { computed, useRuntimeConfig } from '#imports'
 const props = defineProps<{ id?: string }>()
 
 const { headings } = useRuntimeConfig().public.mdc
-const generate = computed(() => props.id && (headings?.anchorLinks === true || (typeof headings?.anchorLinks === 'object' && headings?.anchorLinks?.h6)))
+const generate = computed(() => props.id && ((typeof headings?.anchorLinks === 'boolean' && headings?.anchorLinks === true) || (typeof headings?.anchorLinks === 'object' && headings?.anchorLinks?.h6)))
 </script>


### PR DESCRIPTION
## Build fixes

Fix build by referencing `runtime/*.js` files rather than `*.mjs`.

`@nuxt/module-builder` [introduced a breaking change in 0.7.0](https://github.com/nuxt/module-builder/releases/tag/v0.7.0) to use `.js` extension for files in the `runtime/` directory

## Types

The `ProseH*.vue` components still had a type checking error. This PR resolves the types.