### PR TITLE
fix: `defineConfig` should be side-effect free

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import type { MdcConfig } from './types';
+import type { MdcConfig } from './types'
 
 export function defineConfig(config: MdcConfig) {
   return config

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import type { MdcConfig } from './types'
 
-export function defineConfig(config: MdcConfig) {
+export function defineConfig(config: MdcConfig): MdcConfig {
   return config
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import type { MdcConfig } from './types'
+import type { MdcConfig } from './types/config'
 
 export function defineConfig(config: MdcConfig): MdcConfig {
   return config

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,1 +1,5 @@
-export { defineConfig } from './module'
+import type { MdcConfig } from './types';
+
+export function defineConfig(config: MdcConfig) {
+  return config
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,16 +3,14 @@ import { defineNuxtModule, extendViteConfig, addComponent, addComponentsDir, cre
 import { defu } from 'defu'
 import { resolve } from 'pathe'
 import type { BundledLanguage } from 'shiki'
-import type { ModuleOptions, MdcConfig } from './types'
+import type { ModuleOptions } from './types'
 import { registerMDCSlotTransformer } from './utils/vue-mdc-slot'
 import * as templates from './templates'
 import { addWasmSupport } from './utils'
 
 export type * from './types'
 
-export function defineConfig(config: MdcConfig) {
-  return config
-}
+export { defineConfig } from './config'
 
 export const DefaultHighlightLangs: BundledLanguage[] = [
   'js',


### PR DESCRIPTION
In the latest version, importing `@nuxtjs/mdc/config` (used in runtime, mdc.config.js) would imports the whole `@nuxtjs/mdc`, which is node side. This is because the `dist/config.mjs` get bundled as:

```ts
export { defineConfig } from './module.mjs'; // <-- this introduce side-effects
import 'node:fs';
import '@nuxt/kit';
import 'defu';
import 'pathe';
import 'node:fs/promises';
import 'scule';
```

Which was introduced in https://github.com/nuxt-modules/mdc/issues/226

This would cost `nuxt-content-twoslash` gets error like this: (would appear in every usage in `mdc.config.js` 

<img width="1198" alt="Screenshot 2024-06-27 at 15 05 47" src="https://github.com/nuxt-modules/mdc/assets/11247099/5b702533-4640-45d7-879f-078e0e4dcd0e">
