### PR TITLE
fix: Use explicit `props`

### DIFF
--- a/src/runtime/components/MDC.vue
+++ b/src/runtime/components/MDC.vue
@@ -8,7 +8,7 @@
   >
     <MDCRenderer
       v-if="body"
-      :tag="tag"
+      :tag="props.tag"
       :class="props.class"
       :body="body"
       :data="data?.data"

--- a/src/runtime/components/prose/ProseA.vue
+++ b/src/runtime/components/prose/ProseA.vue
@@ -10,7 +10,7 @@
 <script setup lang="ts">
 import type { PropType } from 'vue'
 
-defineProps({
+const props = defineProps({
   href: {
     type: String,
     default: ''

--- a/src/runtime/components/prose/ProseA.vue
+++ b/src/runtime/components/prose/ProseA.vue
@@ -1,7 +1,7 @@
 <template>
   <NuxtLink
-    :href="href"
-    :target="target"
+    :href="props.href"
+    :target="props.target"
   >
     <slot />
   </NuxtLink>

--- a/src/runtime/components/prose/ProseH1.vue
+++ b/src/runtime/components/prose/ProseH1.vue
@@ -1,8 +1,8 @@
 <template>
-  <h1 :id="id">
+  <h1 :id="props.id">
     <a
       v-if="generate"
-      :href="`#${id}`"
+      :href="`#${props.id}`"
     >
       <slot />
     </a>

--- a/src/runtime/components/prose/ProseH2.vue
+++ b/src/runtime/components/prose/ProseH2.vue
@@ -1,8 +1,8 @@
 <template>
-  <h2 :id="id">
+  <h2 :id="props.id">
     <a
-      v-if="id && generate"
-      :href="`#${id}`"
+      v-if="props.id && generate"
+      :href="`#${props.id}`"
     >
       <slot />
     </a>

--- a/src/runtime/components/prose/ProseH3.vue
+++ b/src/runtime/components/prose/ProseH3.vue
@@ -1,8 +1,8 @@
 <template>
-  <h3 :id="id">
+  <h3 :id="props.id">
     <a
-      v-if="id && generate"
-      :href="`#${id}`"
+      v-if="props.id && generate"
+      :href="`#${props.id}`"
     >
       <slot />
     </a>

--- a/src/runtime/components/prose/ProseH4.vue
+++ b/src/runtime/components/prose/ProseH4.vue
@@ -1,8 +1,8 @@
 <template>
-  <h4 :id="id">
+  <h4 :id="props.id">
     <a
-      v-if="id && generate"
-      :href="`#${id}`"
+      v-if="props.id && generate"
+      :href="`#${props.id}`"
     >
       <slot />
     </a>

--- a/src/runtime/components/prose/ProseH5.vue
+++ b/src/runtime/components/prose/ProseH5.vue
@@ -1,8 +1,8 @@
 <template>
-  <h5 :id="id">
+  <h5 :id="props.id">
     <a
-      v-if="id && generate"
-      :href="`#${id}`"
+      v-if="props.id && generate"
+      :href="`#${props.id}`"
     >
       <slot />
     </a>

--- a/src/runtime/components/prose/ProseH6.vue
+++ b/src/runtime/components/prose/ProseH6.vue
@@ -1,8 +1,8 @@
 <template>
-  <h6 :id="id">
+  <h6 :id="props.id">
     <a
-      v-if="id && generate"
-      :href="`#${id}`"
+      v-if="props.id && generate"
+      :href="`#${props.id}`"
     >
       <slot />
     </a>

--- a/src/runtime/components/prose/ProseImg.vue
+++ b/src/runtime/components/prose/ProseImg.vue
@@ -2,9 +2,9 @@
   <component
     :is="imgComponent"
     :src="refinedSrc"
-    :alt="alt"
-    :width="width"
-    :height="height"
+    :alt="props.alt"
+    :width="props.width"
+    :height="props.height"
   />
 </template>
 


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In vue 3.5 and latest Nuxt version, typing errors are thrown when accessing `props` directly. These errors look like:

```sh
node_modules/@nuxtjs/mdc/dist/runtime/components/prose/ProseH6.vue:2:12 - error TS2339: Property 'id' does not exist on type 'CreateComponentPublicInstanceWithMixins<Readonly<{}> & Readonly<{}>, { generate: typeof generate; }, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, ... 17 more ..., {}>'.

2   <h6 :id="id">
             ~~

node_modules/@nuxtjs/mdc/dist/runtime/components/prose/ProseH6.vue:4:13 - error TS2339: Property 'id' does not exist on type 'CreateComponentPublicInstanceWithMixins<Readonly<{}> & Readonly<{}>, { generate: typeof generate; }, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, ... 17 more ..., {}>'.

4       v-if="id && generate"
```

This change makes accessing these props explicit (e.g. `props.id`) and consistent.


