### PR TITLE
feat: introduce `highlight.shikiEngine` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "^3.13.1",
-    "@shikijs/transformers": "^1.17.0",
+    "@shikijs/transformers": "^1.17.7",
     "@types/hast": "^3.0.4",
     "@types/mdast": "^4.0.4",
     "@vue/compiler-core": "^3.5.4",
@@ -100,7 +100,7 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.0",
     "scule": "^1.3.0",
-    "shiki": "^1.17.0",
+    "shiki": "^1.17.7",
     "ufo": "^1.5.4",
     "unified": "^11.0.5",
     "unist-builder": "^4.0.0",

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -3,12 +3,14 @@ export default defineNuxtConfig({
     '@nuxt/ui',
     '../src/module'
   ],
+
   mdc: {
     highlight: {
       theme: {
         default: 'vitesse-light',
         dark: 'material-theme-palenight'
       },
+      shikiEngine: 'javascript',
       preload: [
         'sql'
       ]
@@ -23,7 +25,10 @@ export default defineNuxtConfig({
       }
     }
   },
+
   devtools: {
     enabled: true
-  }
+  },
+
+  compatibilityDate: '2024-09-16'
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.13.1
         version: 3.13.1(magicast@0.3.5)(rollup@3.29.4)
       '@shikijs/transformers':
-        specifier: ^1.17.0
-        version: 1.17.0
+        specifier: ^1.17.7
+        version: 1.17.7
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -96,8 +96,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       shiki:
-        specifier: ^1.17.0
-        version: 1.17.0
+        specifier: ^1.17.7
+        version: 1.17.7
       ufo:
         specifier: ^1.5.4
         version: 1.5.4
@@ -1482,20 +1482,20 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@shikijs/core@1.17.0':
-    resolution: {integrity: sha512-Mkk4Mp4bNnW1kytU8I7S5PK5teNSe0iKlfqxPss4sdwnlcU8a2N62Z3te2gVmZfU9t1HF6L3wyWuM43IvEeEsg==}
+  '@shikijs/core@1.17.7':
+    resolution: {integrity: sha512-ZnIDxFu/yvje3Q8owSHaEHd+bu/jdWhHAaJ17ggjXofHx5rc4bhpCSW+OjC6smUBi5s5dd023jWtZ1gzMu/yrw==}
 
-  '@shikijs/engine-javascript@1.17.0':
-    resolution: {integrity: sha512-EiBVlxmzJZdC2ypzn8k+vxLngbBNgHLS4RilwrFOABGRc72kUZubbD/6Chrq2RcVtD3yq1GtiiIdFMGd9BTX3Q==}
+  '@shikijs/engine-javascript@1.17.7':
+    resolution: {integrity: sha512-wwSf7lKPsm+hiYQdX+1WfOXujtnUG6fnN4rCmExxa4vo+OTmvZ9B1eKauilvol/LHUPrQgW12G3gzem7pY5ckw==}
 
-  '@shikijs/engine-oniguruma@1.17.0':
-    resolution: {integrity: sha512-nsXzJGLQ0fhKmA4Gwt1cF7vC8VuZ1HSDrTRuj48h/qDeX/TzmOlTDXQ3uPtyuhyg/2rbZRzNhN8UFU4fSnQfXg==}
+  '@shikijs/engine-oniguruma@1.17.7':
+    resolution: {integrity: sha512-pvSYGnVeEIconU28NEzBXqSQC/GILbuNbAHwMoSfdTBrobKAsV1vq2K4cAgiaW1TJceLV9QMGGh18hi7cCzbVQ==}
 
-  '@shikijs/transformers@1.17.0':
-    resolution: {integrity: sha512-C/s6z0knkWBVRG6cmklTUn+70URKVE8qlQuFg6Bi/9iqpX68NZloZhxCtVHeTd56pit15hivTlgSAY+SP7C8hA==}
+  '@shikijs/transformers@1.17.7':
+    resolution: {integrity: sha512-Nu7DaUT/qHDqbEsWBBqX6MyPMFbR4hUZcK11TA+zU/nPu9eDFE8v0p+n+eT4A3+3mxX6czMSF81W4QNsQ/NSpQ==}
 
-  '@shikijs/types@1.17.0':
-    resolution: {integrity: sha512-Tvu2pA69lbpXB+MmgIaROP1tio8y0uYvKb5Foh3q0TJBTAJuaoa5eDEtS/0LquyveacsiVrYF4uEZILju+7Ybg==}
+  '@shikijs/types@1.17.7':
+    resolution: {integrity: sha512-+qA4UyhWLH2q4EFd+0z4K7GpERDU+c+CN2XYD3sC+zjvAr5iuwD1nToXZMt1YODshjkEGEDV86G7j66bKjqDdg==}
 
   '@shikijs/vscode-textmate@9.2.2':
     resolution: {integrity: sha512-TMp15K+GGYrWlZM8+Lnj9EaHEFmOen0WJBrfa17hF7taDOYthuPPV0GWzfd/9iMij0akS/8Yw2ikquH7uVi/fg==}
@@ -4171,8 +4171,8 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
-  oniguruma-to-js@0.3.3:
-    resolution: {integrity: sha512-m90/WEhgs8g4BxG37+Nu3YrMfJDs2YXtYtIllhsEPR+wP3+K4EZk6dDUvy2v2K4MNFDDOYKL4/yqYPXDqyozTQ==}
+  oniguruma-to-js@0.4.3:
+    resolution: {integrity: sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==}
 
   only@0.0.2:
     resolution: {integrity: sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==}
@@ -4948,8 +4948,8 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  shiki@1.17.0:
-    resolution: {integrity: sha512-VZf8cPShRwfzPcaswv81+YP7qJEoFwRT+Ehy6bizim7M0zG9bk8Egug550C+xS9g7rKIOPhzAlp2uEyuCxbk/A==}
+  shiki@1.17.7:
+    resolution: {integrity: sha512-Zf6hNtWhFyF4XP5OOsXkBTEx9JFPiN0TQx4wSe+Vqeuczewgk2vT4IZhF4gka55uelm052BD5BaHavNqUNZd+A==}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -7454,31 +7454,31 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.21.3':
     optional: true
 
-  '@shikijs/core@1.17.0':
+  '@shikijs/core@1.17.7':
     dependencies:
-      '@shikijs/engine-javascript': 1.17.0
-      '@shikijs/engine-oniguruma': 1.17.0
-      '@shikijs/types': 1.17.0
+      '@shikijs/engine-javascript': 1.17.7
+      '@shikijs/engine-oniguruma': 1.17.7
+      '@shikijs/types': 1.17.7
       '@shikijs/vscode-textmate': 9.2.2
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.2
 
-  '@shikijs/engine-javascript@1.17.0':
+  '@shikijs/engine-javascript@1.17.7':
     dependencies:
-      '@shikijs/types': 1.17.0
-      oniguruma-to-js: 0.3.3
-      regex: 4.3.2
+      '@shikijs/types': 1.17.7
+      '@shikijs/vscode-textmate': 9.2.2
+      oniguruma-to-js: 0.4.3
 
-  '@shikijs/engine-oniguruma@1.17.0':
+  '@shikijs/engine-oniguruma@1.17.7':
     dependencies:
-      '@shikijs/types': 1.17.0
+      '@shikijs/types': 1.17.7
       '@shikijs/vscode-textmate': 9.2.2
 
-  '@shikijs/transformers@1.17.0':
+  '@shikijs/transformers@1.17.7':
     dependencies:
-      shiki: 1.17.0
+      shiki: 1.17.7
 
-  '@shikijs/types@1.17.0':
+  '@shikijs/types@1.17.7':
     dependencies:
       '@shikijs/vscode-textmate': 9.2.2
       '@types/hast': 3.0.4
@@ -10904,7 +10904,9 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
-  oniguruma-to-js@0.3.3: {}
+  oniguruma-to-js@0.4.3:
+    dependencies:
+      regex: 4.3.2
 
   only@0.0.2: {}
 
@@ -11830,10 +11832,12 @@ snapshots:
       interpret: 1.4.0
       rechoir: 0.6.2
 
-  shiki@1.17.0:
+  shiki@1.17.7:
     dependencies:
-      '@shikijs/core': 1.17.0
-      '@shikijs/types': 1.17.0
+      '@shikijs/core': 1.17.7
+      '@shikijs/engine-javascript': 1.17.7
+      '@shikijs/engine-oniguruma': 1.17.7
+      '@shikijs/types': 1.17.7
       '@shikijs/vscode-textmate': 9.2.2
       '@types/hast': 3.0.4
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -236,6 +236,7 @@ function resolveOptions(options: ModuleOptions) {
       default: 'github-light',
       dark: 'github-dark'
     }
+    options.highlight.shikiEngine ||= 'oniguruma'
     options.highlight.langs ||= DefaultHighlightLangs
 
     if (options.highlight.preload) {

--- a/src/runtime/highlighter/shiki.ts
+++ b/src/runtime/highlighter/shiki.ts
@@ -1,5 +1,5 @@
 import type { CodeToHastOptions } from 'shiki/core'
-import type { HighlighterCore, LanguageInput, ShikiTransformer, ThemeInput } from 'shiki'
+import type { HighlighterCore, LanguageInput, ShikiTransformer, ThemeInput, RegexEngine } from 'shiki'
 import type { Element } from 'hast'
 import type { MdcConfig, Highlighter } from '@nuxtjs/mdc'
 
@@ -16,6 +16,8 @@ export interface CreateShikiHighlighterOptions {
   options?: { wrapperStyle?: string }
   /* A function to custom mdc configs */
   getMdcConfigs?: () => Promise<MdcConfig[]>
+  /* Shiki regex engine */
+  engine?: RegexEngine
 }
 
 export function createShikiHighlighter({
@@ -24,7 +26,8 @@ export function createShikiHighlighter({
   bundledLangs = {},
   bundledThemes = {},
   getMdcConfigs,
-  options: shikiOptions
+  options: shikiOptions,
+  engine
 }: CreateShikiHighlighterOptions = {}): Highlighter {
   let shiki: ReturnType<typeof _getShiki> | undefined
   let configs: Promise<MdcConfig[]> | undefined
@@ -36,7 +39,7 @@ export function createShikiHighlighter({
     const shiki: HighlighterCore = await createHighlighterCore({
       langs,
       themes,
-      loadWasm: () => import('shiki/wasm')
+      engine
     })
 
     for await (const config of await getConfigs()) {

--- a/src/runtime/highlighter/shiki.ts
+++ b/src/runtime/highlighter/shiki.ts
@@ -17,7 +17,7 @@ export interface CreateShikiHighlighterOptions {
   /* A function to custom mdc configs */
   getMdcConfigs?: () => Promise<MdcConfig[]>
   /* Shiki regex engine */
-  engine?: RegexEngine
+  engine?: RegexEngine | Promise<RegexEngine>
 }
 
 export function createShikiHighlighter({

--- a/src/templates/mdc-highlighter.ts
+++ b/src/templates/mdc-highlighter.ts
@@ -67,10 +67,16 @@ export async function mdcHighlighter({
       ...options?.themes || []
     ]))
 
+    const {
+      shikiEngine = 'oniguruma'
+    } = options
+
     return [
       'import { getMdcConfigs } from \'#mdc-configs\'',
+      shikiEngine === 'javascript'
+        ? 'import { createJavaScriptRegexEngine } from \'shiki/engine/javascript\''
+        : 'import { createWasmOnigEngine } from \'shiki/engine/oniguruma\'',
       code,
-
       'const bundledLangs = {',
       ...Array.from(langsMap.entries())
         .map(([name, lang]) => typeof lang === 'string'
@@ -86,7 +92,10 @@ export async function mdcHighlighter({
         theme: options.theme,
         wrapperStyle: options.wrapperStyle
       }),
-      'const highlighter = createShikiHighlighter({ bundledLangs, bundledThemes, options, getMdcConfigs })',
+      shikiEngine === 'javascript'
+        ? 'const engine = createJavaScriptRegexEngine({ forgiving: true })'
+        : `const engine = createWasmOnigEngine(() => import('shiki/wasm'))`,
+      'const highlighter = createShikiHighlighter({ bundledLangs, bundledThemes, options, getMdcConfigs, engine })',
       'export default highlighter'
     ].join('\n')
   }

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -50,6 +50,16 @@ export interface ModuleOptions {
     themes?: (BundledTheme | ThemeRegistrationAny)[]
 
     /**
+     * Engine to be used for Shiki
+     *
+     * Note that the `javascript` engine still in experimental, use with caution.
+     *
+     * @see https://shiki.style/guide/regex-engines
+     * @default 'oniguruma'
+     */
+    shikiEngine?: 'oniguruma' | 'javascript'
+
+    /**
      * Preloaded languages that will be available for highlighting code blocks.
      *
      * @deprecated use `langs` instead.

--- a/test/utils/parser.ts
+++ b/test/utils/parser.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
+import { createWasmOnigEngine } from 'shiki/engine/oniguruma'
 import { parseMarkdown as _parseMarkDown } from '../../src/runtime/parser'
 import type { MDCParseOptions } from '../../src/types'
 import { rehypeHighlight } from '../../src/runtime/highlighter/rehype-nuxt'
@@ -33,7 +34,8 @@ export const parseMarkdown = (md: string, options: MDCParseOptions = {}) => {
         import('shiki/themes/github-dark.mjs')
       ],
       options: {},
-      getMdcConfigs: async () => []
+      getMdcConfigs: async () => [],
+      engine: createWasmOnigEngine(import('shiki/wasm'))
     })
 
     options.highlight.highlighter = highlighter


### PR DESCRIPTION
This allows the MDC module and Nuxt Content to utilize the new JavaScript engine of Shiki (https://shiki.style/guide/regex-engines), which produces smaller and more portable bundles. Currently, it requires explicit opt-in as the engine is still experimental.