### PR TITLE
fix: do not load `<NuxtImg>` stub if it is not installed

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
-import { defineNuxtModule, extendViteConfig, addComponent, addComponentsDir, createResolver, addServerHandler, addTemplate, addImports, addServerImports, hasNuxtModule } from '@nuxt/kit'
+import { defineNuxtModule, extendViteConfig, addComponent, addComponentsDir, createResolver, addServerHandler, addTemplate, addImports, addServerImports } from '@nuxt/kit'
 import { defu } from 'defu'
 import { resolve } from 'pathe'
 import type { BundledLanguage } from 'shiki'
@@ -167,11 +167,10 @@ export default defineNuxtModule<ModuleOptions>({
       })
     }
 
-    if (hasNuxtModule('@nuxt/image')) {
-      nuxt.options.runtimeConfig.public.mdc = defu(nuxt.options.runtimeConfig.public.mdc, {
-        useNuxtImage: true
-      })
-    }
+    addTemplate({
+      filename: 'mdc-image-component.mjs',
+      getContents: ({ app }) => app.components.some(c => c.pascalName === 'NuxtImg' && !c.filePath.includes('nuxt/dist/app')) ? 'export { NuxtImg } from "#components"' : 'export default "img"'
+    })
 
     // Update Vite optimizeDeps
     extendViteConfig((config) => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -256,7 +256,6 @@ declare module '@nuxt/schema' {
         map: Record<string, string>
       }
       headings: ModuleOptions['headings']
-      useNuxtImage?: boolean
     }
   }
 

--- a/src/runtime/components/prose/ProseImg.vue
+++ b/src/runtime/components/prose/ProseImg.vue
@@ -1,6 +1,6 @@
 <template>
   <component
-    :is="imgComponent"
+    :is="ImageComponent"
     :src="refinedSrc"
     :alt="props.alt"
     :width="props.width"
@@ -12,7 +12,7 @@
 import { withTrailingSlash, withLeadingSlash, joinURL } from 'ufo'
 import { useRuntimeConfig, computed, resolveComponent } from '#imports'
 
-const imgComponent = useRuntimeConfig().public.mdc.useNuxtImage ? resolveComponent('NuxtImg') : 'img'
+import ImageComponent from '#build/mdc-image-component.mjs'
 
 const props = defineProps({
   src: {

--- a/src/runtime/components/prose/ProseImg.vue
+++ b/src/runtime/components/prose/ProseImg.vue
@@ -10,7 +10,7 @@
 
 <script setup lang="ts">
 import { withTrailingSlash, withLeadingSlash, joinURL } from 'ufo'
-import { useRuntimeConfig, computed, resolveComponent } from '#imports'
+import { useRuntimeConfig, computed } from '#imports'
 
 import ImageComponent from '#build/mdc-image-component.mjs'
 


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Feature added in https://github.com/nuxt-modules/mdc/pull/180 to use `<NuxtImg>` under the hood, but now that this is stubbed in Nuxt, this will always result in a transform (and potentially a prompt to install `@nuxt/image` - see https://github.com/nuxt/nuxt/issues/29283).

In future releases of Nuxt this will cause a hard error (https://github.com/nuxt/nuxt/pull/29287), so this PR refactors things to only import from NuxtImg when it doesn't point to a stubbed version. 