### PR TITLE
fix(module): possibility to remove module's default remark/rehype plugins from bundle

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -34,8 +34,21 @@ export default defineNuxtModule<ModuleOptions>({
   },
   // Default configuration options of the Nuxt module
   defaults: {
-    remarkPlugins: {},
-    rehypePlugins: {},
+    remarkPlugins: {
+      'remark-mdc': {},
+      'remark-emoji': {},
+      'remark-gfm': {}
+    },
+    rehypePlugins: {
+      'rehype-external-links': {},
+      'rehype-sort-attribute-values': {},
+      'rehype-sort-attributes': {},
+      'rehype-raw': {
+        options: {
+          passThrough: ['element']
+        }
+      }
+    },
     highlight: false,
     headings: {
       anchorLinks: {

--- a/src/runtime/parser/options.ts
+++ b/src/runtime/parser/options.ts
@@ -1,49 +1,16 @@
-import remarkEmoji from 'remark-emoji'
-import remarkGFM from 'remark-gfm'
-import remarkMDC from 'remark-mdc'
-import rehypeExternalLinks from 'rehype-external-links'
-import rehypeSortAttributeValues from 'rehype-sort-attribute-values'
-import rehypeSortAttributes from 'rehype-sort-attributes'
-import rehypeRaw from 'rehype-raw'
 import type { MDCParseOptions } from '@nuxtjs/mdc'
 import handlers from './handlers'
 
 export const defaults: MDCParseOptions = {
   remark: {
-    plugins: {
-      'remark-mdc': {
-        instance: remarkMDC
-      },
-      'remark-emoji': {
-        instance: remarkEmoji
-      },
-      'remark-gfm': {
-        instance: remarkGFM
-      }
-    }
+    plugins: {}
   },
   rehype: {
     options: {
       handlers,
       allowDangerousHtml: true
     },
-    plugins: {
-      'rehype-external-links': {
-        instance: rehypeExternalLinks
-      },
-      'rehype-sort-attribute-values': {
-        instance: rehypeSortAttributeValues
-      },
-      'rehype-sort-attributes': {
-        instance: rehypeSortAttributes
-      },
-      'rehype-raw': {
-        instance: rehypeRaw,
-        options: {
-          passThrough: ['element']
-        }
-      }
-    }
+    plugins: {}
   },
   highlight: false,
   toc: {

--- a/src/templates/mdc-imports.ts
+++ b/src/templates/mdc-imports.ts
@@ -31,11 +31,15 @@ function processUnistPlugins(plugins: Record<string, UnistPlugin>) {
   const definitions: string[] = []
   Object.entries(plugins).forEach(([name, plugin]) => {
     const instanceName = `_${pascalCase(name).replace(/\W/g, '')}`
-    imports.push(`import ${instanceName} from '${plugin.src || name}'`)
-    if (Object.keys(plugin).length) {
-      definitions.push(`  '${name}': { instance: ${instanceName}, options: ${JSON.stringify(plugin.options || plugin)} },`)
+    if (plugin) {
+      imports.push(`import ${instanceName} from '${plugin.src || name}'`)
+      if (Object.keys(plugin).length) {
+        definitions.push(`  '${name}': { instance: ${instanceName}, options: ${JSON.stringify(plugin.options || plugin)} },`)
+      } else {
+        definitions.push(`  '${name}': { instance: ${instanceName} },`)
+      }
     } else {
-      definitions.push(`  '${name}': { instance: ${instanceName} },`)
+      definitions.push(`  '${name}': false,`)
     }
   })
 

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -10,11 +10,11 @@ export interface ModuleOptions {
   /**
    * A map of remark plugins to be used for processing markdown.
    */
-  remarkPlugins?: Record<string, UnistPlugin>
+  remarkPlugins?: Record<string, UnistPlugin | false>
   /**
    * A map of remark plugins to be used for processing markdown.
    */
-  rehypePlugins?: Record<string, UnistPlugin>
+  rehypePlugins?: Record<string, UnistPlugin | false>
 
   highlight?: {
     /**

--- a/test/utils/parser.ts
+++ b/test/utils/parser.ts
@@ -1,19 +1,43 @@
 import { vi } from 'vitest'
 import { createWasmOnigEngine } from 'shiki/engine/oniguruma'
-import remarkMdc from 'remark-mdc'
-import { parseMarkdown as _parseMarkDown } from '../../src/runtime/parser'
-import type { MDCParseOptions } from '../../src/types'
-import { rehypeHighlight } from '../../src/runtime/highlighter/rehype-nuxt'
+import remarkGFM from 'remark-gfm'
+import remarkMDC from 'remark-mdc'
+import rehypeExternalLinks from 'rehype-external-links'
+import rehypeSortAttributeValues from 'rehype-sort-attribute-values'
+import rehypeSortAttributes from 'rehype-sort-attributes'
+import rehypeRaw from 'rehype-raw'
 import { createShikiHighlighter } from '../../src/runtime/highlighter/shiki'
+import { rehypeHighlight } from '../../src/runtime/highlighter/rehype-nuxt'
+import type { MDCParseOptions } from '../../src/types'
+import { parseMarkdown as _parseMarkDown } from '../../src/runtime/parser'
 
 vi.mock('#mdc-imports', () => {
   return {
     remarkPlugins: {
       'remark-mdc': {
-        instance: remarkMdc
+        instance: remarkMDC
+      },
+      'remark-gfm': {
+        instance: remarkGFM
       }
     },
-    rehypePlugins: {},
+    rehypePlugins: {
+      'rehype-external-links': {
+        instance: rehypeExternalLinks
+      },
+      'rehype-sort-attribute-values': {
+        instance: rehypeSortAttributeValues
+      },
+      'rehype-sort-attributes': {
+        instance: rehypeSortAttributes
+      },
+      'rehype-raw': {
+        instance: rehypeRaw,
+        options: {
+          passThrough: ['element']
+        }
+      }
+    },
     highlight: {}
   }
 })

--- a/test/utils/parser.ts
+++ b/test/utils/parser.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest'
 import { createWasmOnigEngine } from 'shiki/engine/oniguruma'
+import remarkMdc from 'remark-mdc'
 import { parseMarkdown as _parseMarkDown } from '../../src/runtime/parser'
 import type { MDCParseOptions } from '../../src/types'
 import { rehypeHighlight } from '../../src/runtime/highlighter/rehype-nuxt'
@@ -7,7 +8,11 @@ import { createShikiHighlighter } from '../../src/runtime/highlighter/shiki'
 
 vi.mock('#mdc-imports', () => {
   return {
-    remarkPlugins: {},
+    remarkPlugins: {
+      'remark-mdc': {
+        instance: remarkMdc
+      }
+    },
     rehypePlugins: {},
     highlight: {}
   }


### PR DESCRIPTION
### 🔗 Linked issue
resolves https://github.com/nuxt-modules/mdc/issues/187

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Move remark/rehype default plugin to module options so they can disable easily and remove from production bundle.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
