### PR TITLE
feat(slot): detect Vue slots with `mdc-unwrap` prop and treat them as `<MDCSlot>`

### DIFF
--- a/playground/components/mdc/MultiSlot.vue
+++ b/playground/components/mdc/MultiSlot.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>
+    <slot name="header" mdc-unwrap="p" />
+    <slot />
+    <slot name="footer" />
+  </div>
+</template>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -18,15 +18,6 @@ export default defineNuxtConfig({
       preload: [
         'sql'
       ]
-    },
-    remarkPlugins: {
-      'remark-mdc': {
-        options: {
-          experimental: {
-            autoUnwrap: true
-          }
-        }
-      }
     }
   },
 

--- a/src/runtime/utils/slot.ts
+++ b/src/runtime/utils/slot.ts
@@ -3,7 +3,7 @@ import { flatUnwrap } from './node'
 
 export const renderSlot = (slots: Record<string, any>, name: string, props: any, ...rest: any[]) => {
   if (slots[name]) {
-    return _renderSlot({ ...slots, [name]: () => flatUnwrap(slots[name](), props?.unwrap) }, name, props, ...rest)
+    return _renderSlot({ ...slots, [name]: () => flatUnwrap(slots[name](), props?.unwrap || props?.mdcUnwrap) }, name, props, ...rest)
   }
 
   return _renderSlot(slots, name, props, ...rest)

--- a/src/runtime/utils/ssrSlot.ts
+++ b/src/runtime/utils/ssrSlot.ts
@@ -3,7 +3,7 @@ import { flatUnwrap } from './node'
 
 export const ssrRenderSlot = (slots: Record<string, any>, name: string, props: any, fallbackRenderFn: (() => void) | null, push: any, parentComponent: any, slotScopeId?: string | undefined) => {
   if (slots[name]) {
-    return _ssrRenderSlot({ ...slots, [name]: () => flatUnwrap(slots[name](), props?.unwrap) }, name, props, fallbackRenderFn, push, parentComponent, slotScopeId)
+    return _ssrRenderSlot({ ...slots, [name]: () => flatUnwrap(slots[name](), props?.unwrap || props?.mdcUnwrap) }, name, props, fallbackRenderFn, push, parentComponent, slotScopeId)
   }
 
   return _ssrRenderSlot(slots, name, props, fallbackRenderFn, push, parentComponent, slotScopeId)

--- a/src/utils/vue-mdc-slot.ts
+++ b/src/utils/vue-mdc-slot.ts
@@ -1,4 +1,4 @@
-import type { NodeTransform, ElementNode } from '@vue/compiler-core'
+import type { NodeTransform, ElementNode, DirectiveNode } from '@vue/compiler-core'
 import { type Resolver, extendViteConfig } from '@nuxt/kit'
 
 export const registerMDCSlotTransformer = (resolver: Resolver) => {
@@ -6,7 +6,10 @@ export const registerMDCSlotTransformer = (resolver: Resolver) => {
     const compilerOptions = (config as any).vue.template.compilerOptions
     compilerOptions.nodeTransforms = [
       <NodeTransform> function viteMDCSlot(node: ElementNode, context) {
-        if (node.tag === 'MDCSlot') {
+        const isVueSlotWithUnwrap = node.tag === 'slot' && node.props.find(p => p.name === 'mdc-unwrap' || (p.name === 'bind' && (p as DirectiveNode).rawName === ':mdc-unwrap'))
+        const isMDCSlot = node.tag === 'MDCSlot'
+
+        if (isVueSlotWithUnwrap || isMDCSlot) {
           const transform = context.ssr
             ? context.nodeTransforms.find(nt => nt.name === 'ssrTransformSlotOutlet')
             : context.nodeTransforms.find(nt => nt.name === 'transformSlotOutlet')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Using `<MDCSlot>` in a component makes the component dependent on the MDC module, making it unusable without the module.  

To eliminate this dependency, this PR introduces a new approach to managing child content and unwrapping unnecessary Markdown tags during rendering.  

Now, any `<slot>` with the `mdc-unwrap` prop will be treated as an `<MDCSlot>` and handled accordingly.  

```vue
<template>
  <slot mdc-unwrap="p" />
</template>
```

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
