### PR TITLE
fix: `stringifyMarkdown` auto-import

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -160,6 +160,10 @@ export default defineNuxtModule<ModuleOptions>({
     addImports({ from: resolver.resolve('./runtime/parser'), name: 'parseMarkdown', as: 'parseMarkdown' })
     addServerImports([{ from: resolver.resolve('./runtime/parser'), name: 'parseMarkdown', as: 'parseMarkdown' }])
 
+    // Add stringifier
+    addImports({ from: resolver.resolve('./runtime/stringify'), name: 'stringifyMarkdown', as: 'stringifyMarkdown' })
+    addServerImports([{ from: resolver.resolve('./runtime/stringify'), name: 'stringifyMarkdown', as: 'stringifyMarkdown' }])
+
     // Register prose components
     if (options.components?.prose) {
       addComponentsDir({


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #285 (this util is what I was going for with `parseAst`)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As I was going to test the new `stringifyMarkdown` util I've noticed it was not added to Nuxt and Nitro imports.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
