### PR TITLE
fix(stringify)!: use `*` instead `_` for emphsis syntax

### DIFF
--- a/src/runtime/stringify/index.ts
+++ b/src/runtime/stringify/index.ts
@@ -17,7 +17,7 @@ export function createStringifyProcessor(options: MDCStringifyOptions = {}) {
     .use(mdc)
     .use(stringify, {
       bullet: '-',
-      emphasis: '_',
+      emphasis: '*',
       rule: '-',
       listItemIndent: 'one',
       fence: '`',


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Based on https://github.com/syntax-tree/mdast-util-to-markdown/issues/65#issuecomment-2470466050 it is necessary to use `*` instead of `_` fo emphasis. We should use it and suggest users to use it.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
