### PR TITLE
fix: regression in allowed image links using absolute or relative paths

### DIFF
--- a/src/runtime/parser/utils/props.ts
+++ b/src/runtime/parser/utils/props.ts
@@ -15,6 +15,11 @@ function isAnchorLinkAllowed(value: string) {
     .replace(/&#(\d+);?/g, '')
     .replace(/&[a-z]+;?/gi, '')
 
+  // Check if the URL is a relative path
+  if (urlSanitized.startsWith('/') || urlSanitized.startsWith('./') || urlSanitized.startsWith('../')) {
+    return true
+  }
+
   try {
     const url = new URL(urlSanitized)
     if (unsafeLinkPrefix.some(prefix => url.protocol.toLowerCase().startsWith(prefix))) {

--- a/test/markdown/images.test.ts
+++ b/test/markdown/images.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from 'vitest'
+import { parseMarkdown } from '../utils/parser'
+
+const md = `
+# Some headline
+
+Following are some image links:
+
+![absolute image](/path/to/my/image.png)
+
+![relative image](../relative/path/to/image.png)
+
+![image](https://placehold.co/200x200.png)
+
+`.trim()
+
+it('Sanity test for image links, all should be allowed', async () => {
+  const { body } = await parseMarkdown(md)
+
+  expect(body.children[2].children[0].tag).toEqual('img')
+  expect(body.children[2].children[0].props.src).toEqual('/path/to/my/image.png')
+
+  expect(body.children[3].children[0].tag).toEqual('img')
+  expect(body.children[3].children[0].props.src).toEqual('../relative/path/to/image.png')
+
+  expect(body.children[4].children[0].tag).toEqual('img')
+  expect(body.children[4].children[0].props.src).toEqual('https://placehold.co/200x200.png')
+})


### PR DESCRIPTION
### 🔗 Linked issue

Issue #338 

### ❓ Type of change

The following fixes a regression in prior commit which fixed an XSS vulnerability but didn't account for relative or absolute paths.

This code also introduces a sanity test that will catch this in the future.

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

