### PR TITLE
fix: support static file paths

### DIFF
--- a/src/runtime/parser/utils/props.ts
+++ b/src/runtime/parser/utils/props.ts
@@ -15,13 +15,12 @@ function isAnchorLinkAllowed(value: string) {
     .replace(/&#(\d+);?/g, '')
     .replace(/&[a-z]+;?/gi, '')
 
-  // Check if the URL is a relative path
-  if (urlSanitized.startsWith('/') || urlSanitized.startsWith('./') || urlSanitized.startsWith('../')) {
-    return true
-  }
-
   try {
-    const url = new URL(urlSanitized)
+    const url = new URL(urlSanitized, 'http://example.com')
+    if (url.origin === 'http://example.com') {
+      return true
+    }
+
     if (unsafeLinkPrefix.some(prefix => url.protocol.toLowerCase().startsWith(prefix))) {
       return false
     }

--- a/test/markdown/images.test.ts
+++ b/test/markdown/images.test.ts
@@ -10,7 +10,9 @@ Following are some image links:
 
 ![relative image](../relative/path/to/image.png)
 
-![image](https://placehold.co/200x200.png)
+![absolute url](https://placehold.co/200x200.png)
+
+![just a path](__src__/assets/image.png)
 
 `.trim()
 
@@ -25,4 +27,7 @@ it('Sanity test for image links, all should be allowed', async () => {
 
   expect(body.children[4].children[0].tag).toEqual('img')
   expect(body.children[4].children[0].props.src).toEqual('https://placehold.co/200x200.png')
+
+  expect(body.children[5].children[0].tag).toEqual('img')
+  expect(body.children[5].children[0].props.src).toEqual('__src__/assets/image.png')
 })

--- a/test/markdown/xss.test.ts
+++ b/test/markdown/xss.test.ts
@@ -49,12 +49,12 @@ it('XSS payloads with HTML entities should be caught', async () => {
 <a href="jav&#x09;ascript:alert('XSS');">Click Me 1</a>
 <a href="jav&#x0A;ascript:alert('XSS');">Click Me 2</a>  
 <a href="jav&#10;ascript:alert('XSS');">Click Me 3</a>
-  
+<a href="&#x09;javascript:alert('XSS');">Click Me 4</a>
 
 `.trim()
 
   // set the number of assertions to expect
-  expect.assertions(4)
+  expect.assertions(5)
 
   const { data, body } = await parseMarkdown(md)
 


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up from fixes to support static file paths like `src/assets` where there is no leading directory character

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
