### PR TITLE
docs: Clarifies the need to globally register the custom prose components

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,23 @@ export default defineNuxtConfig({
 })
 ```
 
+In order to customize these components yourself simply make a component with the same name of the prose component you are trying to take control over. Make sure to put these prose components in their own prose folder and tell nuxt to globally register them so that MDC can get proper access. 
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/mdc'],
+  mdc: {
+    components: {
+      prose: true
+    }
+  },
+  components: {
+    global: true,
+    path: './components/prose'
+  }
+})
+```
+
 Here is the list of available prose components:
 
 | Tag | Component | Source | Description |


### PR DESCRIPTION
### 🔗 Linked issues
resolves #346 and #175 and possibly #342
 
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

The docs don't tell you that custom prose components need to be globally registered for MDC to pick up on them. Multiple users seem to have been confused by this. It's possible that globally registering the prose components is not the preferred solution but to the best of my knowledge this is how to do it. 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
