### PR TITLE
!fix(MDC): do not generate title/description and toc

### DIFF
--- a/src/runtime/components/MDC.vue
+++ b/src/runtime/components/MDC.vue
@@ -72,6 +72,13 @@ const props = defineProps({
   cacheKey: {
     type: String,
     default: undefined
+  },
+  /**
+   * Partial parsing (if partial is `true`, title and toc generation will not be generated)
+   */
+  partial: {
+    type: Boolean,
+    default: true
   }
 })
 
@@ -81,7 +88,11 @@ const { data, refresh, error } = await useAsyncData(key.value, async () => {
   if (typeof props.value !== 'string') {
     return props.value
   }
-  return await parseMarkdown(props.value, props.parserOptions)
+  return await parseMarkdown(props.value, {
+    ...props.parserOptions,
+    toc: props.partial ? false : props.parserOptions?.toc,
+    contentHeading: props.partial ? false : props.parserOptions?.contentHeading
+  })
 })
 
 const body = computed(() => props.excerpt ? data.value?.excerpt : data.value?.body)

--- a/src/runtime/parser/index.ts
+++ b/src/runtime/parser/index.ts
@@ -117,28 +117,29 @@ export const createMarkdownParser = async (inlineOptions: MDCParseOptions = {}) 
       })
     })
 
-    const result = processedFile?.result as { body: MDCRoot, excerpt: MDCRoot | undefined }
+    const parsedContent = processedFile?.result as { body: MDCRoot, excerpt: MDCRoot | undefined }
 
     // Update data with processor data
     const data = Object.assign(
-      inlineOptions.contentHeading !== false ? contentHeading(result.body) : {},
+      inlineOptions.contentHeading !== false ? contentHeading(parsedContent.body) : {},
       frontmatter,
       processedFile?.data || {}
     ) as MDCData
 
-    // Generate toc if it is not disabled in front-matter
-    let toc: Toc | undefined
-    if (data.toc !== false) {
-      const tocOption = defu(data.toc || {}, inlineOptions.toc, defaults.toc)
-      toc = generateToc(result.body, tocOption)
+    const parsedResult = { data, body: parsedContent.body } as MDCParserResult
+
+    // Generate toc if it is not disabled
+    const userTocOption = data.toc ?? inlineOptions.toc
+    if (userTocOption !== false) {
+      const tocOption = defu({} as Toc, userTocOption, defaults.toc)
+      parsedResult.toc = generateToc(parsedContent.body, tocOption)
     }
 
-    return {
-      data,
-      body: result.body,
-      excerpt: result.excerpt,
-      toc
+    if (parsedContent.excerpt) {
+      parsedResult.excerpt = parsedContent.excerpt
     }
+
+    return parsedResult
   }
 }
 

--- a/src/types/parser.ts
+++ b/src/types/parser.ts
@@ -32,7 +32,7 @@ export interface MDCParseOptions {
      */
     depth?: number
     searchDepth?: number
-  }
+  } | false
 
   keepComments?: boolean
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR changes the default behavior of MDC component. MDC component will treat markdown contents as partial contents, meaning that auto-generated  fields (title, description and toc) will not generate.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
