### PR TITLE
fix(cache): fix issue where value watch could get out of sync

### DIFF
--- a/src/runtime/components/MDCCached.vue
+++ b/src/runtime/components/MDCCached.vue
@@ -108,7 +108,7 @@ const body = computed(() => props.excerpt ? data.value?.excerpt : data.value?.bo
 
 watch(() => props.value, () => {
   refresh()
-})
+}, { immediate: true })
 
 // Simple string hashing function
 function hashString(str: string | object) {


### PR DESCRIPTION
Fixes cache where `MDCCached` could value prop could get out of sync.


Closes #384 