### PR TITLE
fix: detect mdcUnwrap on slots too

### DIFF
--- a/src/utils/vue-mdc-slot.ts
+++ b/src/utils/vue-mdc-slot.ts
@@ -6,7 +6,7 @@ export const registerMDCSlotTransformer = (resolver: Resolver) => {
     const compilerOptions = (config as any).vue.template.compilerOptions
     compilerOptions.nodeTransforms = [
       <NodeTransform> function viteMDCSlot(node: ElementNode, context) {
-        const isVueSlotWithUnwrap = node.tag === 'slot' && node.props.find(p => p.name === 'mdc-unwrap' || (p.name === 'bind' && (p as DirectiveNode).rawName === ':mdc-unwrap'))
+        const isVueSlotWithUnwrap = node.tag === 'slot' && node.props.find(p => p.name === 'mdc-unwrap' || p.name === 'mdcUnwrap' || (p.name === 'bind' && (p as DirectiveNode).rawName === ':mdc-unwrap'))
         const isMDCSlot = node.tag === 'MDCSlot'
 
         if (isVueSlotWithUnwrap || isMDCSlot) {


### PR DESCRIPTION
### 🔗 Linked issue

No issue yet

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This PR adds support for the camelCase variant of `mdc-unwrap` to be detected as well. This casing is what Vue officially recommends for props ([see the docs](https://vuejs.org/guide/components/props.html#prop-name-casing)).

We noticed unwrap didn't work for us as the official `vue/prop-name-casing` ESLint rule autofixes props to `camelCase` for us. ([see the docs](https://eslint.vuejs.org/rules/prop-name-casing.html))

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
