### PR TITLE
fix(docs): remark and rehype plugin syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,17 +248,25 @@ export default defineNuxtConfig({
   modules: ['@nuxtjs/mdc'],
   mdc: {
     remarkPlugins: {
-      plugins: {
-        // Register/Configure remark plugin to extend the parser
-      }
+      // Register/Configure remark plugin to extend the parser, e.g.
+      // 'remark-math': {
+      //   src: 'remark-math',
+      //   options: {
+      //     singleDollarTextMath: true,
+      //   },
+      // },
     },
     rehypePlugins: {
-      options: {
-        // Configure rehype options to extend the parser
-      },
-      plugins: {
-        // Register/Configure rehype plugin to extend the parser
-      }
+      // Register/Configure rehype plugin to extend the parser, e.g.
+      // 'rehype-mathjax': {
+      //   src: 'rehype-mathjax',
+      //   options: {
+      //     tex: {
+      //       inlineMath: [['$', '$'], ['\\(', '\\)']],
+      //       displayMath: [['$$', '$$'], ['\\[', '\\]']],
+      //     },
+      //   },
+      // },
     },
     headings: {
       anchorLinks: {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #242 

### ❓ Type of change

Fixes syntax for remark and rehype plugins in README, which currently doesn't match the implementation.

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
